### PR TITLE
Allow update to remove attributes from scimPerson

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -476,7 +476,7 @@ public class CopyUtils implements Serializable {
 		if (items == null) {
 			log.trace(" removing " + attributeName);
 			destination.removeAttribute("oxTrustEmail");
-		} else if (items.size() > 0) {
+		} else {
 			log.trace(" setting " + attributeName);
 
 			StringWriter listOfItems = new StringWriter();

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -475,7 +475,7 @@ public class CopyUtils implements Serializable {
 			throws JsonGenerationException, JsonMappingException, IOException {
 		if (items == null) {
 			log.trace(" removing " + attributeName);
-			destination.removeAttribute("oxTrustEmail");
+			destination.removeAttribute(attributeName);
 		} else {
 			log.trace(" setting " + attributeName);
 


### PR DESCRIPTION
Hi,
The current implementation of CopyUtils does not allow for the removal of attributes or even remove the last item in a set of items. I changed the code to allow for removal and empty attributes during the update. I could have a look at updating the entire CopyUtils but currently have only modified the part I have tests for.