### PR TITLE
Rework of CopyUtils 

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/action/Authenticator.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/Authenticator.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.gluu.oxtrust.ldap.service.ApplianceService;
 import org.gluu.oxtrust.ldap.service.AuthenticationService;
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.SecurityService;
 import org.gluu.oxtrust.model.GluuAppliance;
 import org.gluu.oxtrust.model.GluuCustomPerson;
@@ -101,7 +101,7 @@ public class Authenticator implements Serializable {
 	Redirect redirect;
 	
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private SecurityService securityService;

--- a/server/src/main/java/org/gluu/oxtrust/action/ConfigureCacheRefreshAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/ConfigureCacheRefreshAction.java
@@ -22,9 +22,9 @@ import org.gluu.oxtrust.ldap.cache.service.CacheRefreshService;
 import org.gluu.oxtrust.ldap.cache.service.CacheRefreshUpdateMethod;
 import org.gluu.oxtrust.ldap.service.ApplianceService;
 import org.gluu.oxtrust.ldap.service.AttributeService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.InumService;
 import org.gluu.oxtrust.ldap.service.JsonConfigurationService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.ldap.service.TemplateService;
 import org.gluu.oxtrust.model.GluuAppliance;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
@@ -78,7 +78,7 @@ public class ConfigureCacheRefreshAction implements SimplePropertiesListModel, S
 	private TemplateService templateService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private ExternalCacheRefreshService externalCacheRefreshService;

--- a/server/src/main/java/org/gluu/oxtrust/action/PasswordValidationAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/PasswordValidationAction.java
@@ -14,7 +14,7 @@ import javax.faces.context.FacesContext;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.site.ldap.persistence.exception.AuthenticationException;
 import org.jboss.seam.ScopeType;
@@ -41,7 +41,7 @@ public class PasswordValidationAction implements Cloneable, Serializable {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	private String oldPassword = "";
 

--- a/server/src/main/java/org/gluu/oxtrust/action/PersonImportAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/PersonImportAction.java
@@ -23,7 +23,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.gluu.oxtrust.ldap.load.conf.ImportPersonConfiguration;
 import org.gluu.oxtrust.ldap.service.ExcelService;
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.table.Table;
 import org.gluu.oxtrust.util.OxTrustConstants;
@@ -68,7 +68,7 @@ public class PersonImportAction implements Serializable {
 	StatusMessages statusMessages;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private transient ExcelService excelService;

--- a/server/src/main/java/org/gluu/oxtrust/action/RegisterPersonAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/RegisterPersonAction.java
@@ -21,8 +21,8 @@ import javax.validation.constraints.Size;
 import net.tanesha.recaptcha.ReCaptchaResponse;
 
 import org.gluu.oxtrust.ldap.service.AttributeService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.OrganizationService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuOrganization;
@@ -80,7 +80,7 @@ public class RegisterPersonAction implements Serializable {
 	private GluuCustomPerson person;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@NotNull
 	@Size(min = 2, max = 30, message = "Length of password should be between 2 and 30")

--- a/server/src/main/java/org/gluu/oxtrust/action/SearchGroupAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/SearchGroupAction.java
@@ -12,7 +12,7 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
 import org.gluu.oxtrust.model.GluuGroup;
 import org.gluu.oxtrust.util.OxTrustConstants;
 import org.jboss.seam.ScopeType;
@@ -52,7 +52,7 @@ public class SearchGroupAction implements Serializable {
 	private List<GluuGroup> groupList;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@Restrict("#{s:hasPermission('group', 'access')}")
 	public String start() {

--- a/server/src/main/java/org/gluu/oxtrust/action/SearchPersonAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/SearchPersonAction.java
@@ -12,7 +12,7 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.util.OxTrustConstants;
 import org.jboss.seam.ScopeType;
@@ -52,7 +52,7 @@ public class SearchPersonAction implements Serializable {
 	private List<GluuCustomPerson> personList;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@Restrict("#{s:hasPermission('person', 'access')}")
 	public String start() {

--- a/server/src/main/java/org/gluu/oxtrust/action/UpdateGroupAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/UpdateGroupAction.java
@@ -17,9 +17,9 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.OrganizationService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuGroup;
 import org.gluu.oxtrust.model.GluuOrganization;
@@ -77,13 +77,13 @@ public class UpdateGroupAction implements Serializable {
 	protected GluuCustomPerson currentPerson;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@In
 	private LookupService lookupService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private FacesMessages facesMessages;

--- a/server/src/main/java/org/gluu/oxtrust/action/UpdatePersonAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/UpdatePersonAction.java
@@ -17,8 +17,8 @@ import java.util.Set;
 
 import org.gluu.oxtrust.ldap.service.AttributeService;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.OrganizationService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuGroup;
@@ -66,7 +66,7 @@ public class UpdatePersonAction implements Serializable {
 	private AttributeService attributeService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In(create = true)
 	@Out(scope = ScopeType.CONVERSATION)

--- a/server/src/main/java/org/gluu/oxtrust/action/UserPasswordAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/UserPasswordAction.java
@@ -8,7 +8,7 @@ package org.gluu.oxtrust.action;
 
 import java.io.Serializable;
 
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.util.OxTrustConstants;
 import org.gluu.site.ldap.persistence.exception.AuthenticationException;
@@ -38,7 +38,7 @@ public class UserPasswordAction implements Serializable {
 	private GluuCustomPerson person;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	public String validatePassword() {
 		String result;

--- a/server/src/main/java/org/gluu/oxtrust/action/UserProfileAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/UserProfileAction.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.gluu.oxtrust.ldap.service.AttributeService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.ImageService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.util.OxTrustConstants;
@@ -49,7 +49,7 @@ public class UserProfileAction implements Serializable {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private AttributeService attributeService;

--- a/server/src/main/java/org/gluu/oxtrust/action/WhitePagesAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/WhitePagesAction.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.gluu.oxtrust.ldap.service.AttributeService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.ImageService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.util.OxTrustConstants;
@@ -60,7 +60,7 @@ public class WhitePagesAction implements Serializable {
 	private ImageService imageService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	private String tableState;
 

--- a/server/src/main/java/org/gluu/oxtrust/ldap/cache/service/CacheRefreshTimer.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/cache/service/CacheRefreshTimer.java
@@ -32,8 +32,8 @@ import org.gluu.oxtrust.ldap.cache.model.GluuInumMap;
 import org.gluu.oxtrust.ldap.cache.model.GluuSimplePerson;
 import org.gluu.oxtrust.ldap.service.ApplianceService;
 import org.gluu.oxtrust.ldap.service.AttributeService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.InumService;
-import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuAppliance;
 import org.gluu.oxtrust.model.GluuCustomAttribute;
 import org.gluu.oxtrust.model.GluuCustomPerson;
@@ -102,7 +102,7 @@ public class CacheRefreshTimer {
 	private CacheRefreshService cacheRefreshService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private LdapEntryManager ldapEntryManager;

--- a/server/src/main/java/org/gluu/oxtrust/ldap/cache/service/CacheRefreshTimer.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/cache/service/CacheRefreshTimer.java
@@ -705,7 +705,7 @@ public class CacheRefreshTimer {
 
 			// Remove person from target server
 			try {
-				targetLdapEntryManager.remove(removedPerson);
+				targetLdapEntryManager.removeWithSubtree(removedPerson.getDn());
 				result1.add(inum);
 			} catch (LdapMappingException ex) {
 				log.error("Failed to remove person entry with inum '{0}' and DN: {1}", ex, inum, removedPerson.getDn());

--- a/server/src/main/java/org/gluu/oxtrust/ldap/load/conf/ImportPersonConfiguration.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/load/conf/ImportPersonConfiguration.java
@@ -68,8 +68,8 @@ public class ImportPersonConfiguration {
 			return result;
 		}
 		//issue 102
-		Iterator<?> keys = oxTrustConfiguration.getApplicationConfiguration().getGluuImportPerson().keySet().iterator();
-		//Iterator<?> keys = importConfiguration.getProperties().keySet().iterator();
+//		Iterator<?> keys = oxTrustConfiguration.getApplicationConfiguration().getGluuImportPerson().keySet().iterator();
+		Iterator<?> keys = importConfiguration.getProperties().keySet().iterator();
 		while (keys.hasNext()) {
 			String key = (String) keys.next();
 

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/AttributeService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/AttributeService.java
@@ -379,7 +379,7 @@ public class AttributeService  extends org.xdi.service.AttributeService{
 	 *            Attribute
 	 */
 	public boolean removeAttribute(GluuAttribute attribute) {
-		PersonService personService = PersonService.instance();
+		IPersonService personService = PersonService.instance();
 		log.info("Attribute removal started");
 		log.trace("Getting attribute information");
 		

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/GroupService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/GroupService.java
@@ -38,7 +38,7 @@ import com.unboundid.ldap.sdk.Filter;
 @Scope(ScopeType.STATELESS)
 @Name("groupService")
 @AutoCreate
-public class GroupService implements Serializable {
+public class GroupService implements Serializable, IGroupService {
 
 	/**
      *
@@ -54,22 +54,18 @@ public class GroupService implements Serializable {
 	@In(value = "#{oxTrustConfiguration.applicationConfiguration}")
 	private ApplicationConfiguration applicationConfiguration;
 
-	/**
-	 * Add new group entry
-	 * 
-	 * @param group
-	 *            Group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#addGroup(org.gluu.oxtrust.model.GluuGroup)
 	 */
+	@Override
 	public void addGroup(GluuGroup group) throws Exception {
 		ldapEntryManager.persist(group);
 	}
 
-	/**
-	 * Remove group entry
-	 * 
-	 * @param group
-	 *            Group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#removeGroup(org.gluu.oxtrust.model.GluuGroup)
 	 */
+	@Override
 	public void removeGroup(GluuGroup group) {
 		if (group.getMembers() != null) {
 			List<String> memberDNs = group.getMembers();
@@ -88,24 +84,18 @@ public class GroupService implements Serializable {
 		// clear references in gluuPerson entries
 	}
 
-	/**
-	 * Get all groups
-	 * 
-	 * @return List of groups
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getAllGroups()
 	 */
+	@Override
 	public List<GluuGroup> getAllGroups() {
 		return ldapEntryManager.findEntries(getDnForGroup(null), GluuGroup.class, null);
 	}
 
-	/**
-	 * Check if person is a member or owner of specified group
-	 * 
-	 * @param groupDN
-	 *            Group DN
-	 * @param personDN
-	 *            Person DN
-	 * @return True if person is a member or owner of specified group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#isMemberOrOwner(java.lang.String, java.lang.String)
 	 */
+	@Override
 	public boolean isMemberOrOwner(String groupDN, String personDN) {
 		Filter ownerFilter = Filter.createEqualityFilter(OxTrustConstants.owner, personDN);
 		Filter memberFilter = Filter.createEqualityFilter(OxTrustConstants.member, personDN);
@@ -122,13 +112,10 @@ public class GroupService implements Serializable {
 		return isMemberOrOwner;
 	}
 
-	/**
-	 * Get group by inum
-	 * 
-	 * @param inum
-	 *            Group Inum
-	 * @return Group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getGroupByInum(java.lang.String)
 	 */
+	@Override
 	public GluuGroup getGroupByInum(String inum) {
 		GluuGroup result = null;
 		try{
@@ -140,15 +127,10 @@ public class GroupService implements Serializable {
 
 	}
 
-	/**
-	 * Build DN string for group
-	 * 
-	 * @param inum
-	 *            Group Inum
-	 * @return DN string for specified group or DN for groups branch if inum is
-	 *         null
-	 * @throws Exception
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getDnForGroup(java.lang.String)
 	 */
+	@Override
 	public String getDnForGroup(String inum) {
 		String orgDn = OrganizationService.instance().getDnForOrganization();
 		if (StringHelper.isEmpty(inum)) {
@@ -158,17 +140,19 @@ public class GroupService implements Serializable {
 		return String.format("inum=%s,ou=groups,%s", inum, orgDn);
 	}
 
-	/**
-	 * Update group entry
-	 * 
-	 * @param group
-	 *            Group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#updateGroup(org.gluu.oxtrust.model.GluuGroup)
 	 */
+	@Override
 	public void updateGroup(GluuGroup group) throws Exception {
 		ldapEntryManager.merge(group);
 
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#countGroups()
+	 */
+	@Override
 	public int countGroups() {
 		GluuGroup gluuGroup = new GluuGroup();
 		gluuGroup.setBaseDn(getDnForGroup(null));
@@ -176,12 +160,10 @@ public class GroupService implements Serializable {
 		return ldapEntryManager.countEntries(gluuGroup);
 	}
 
-	/**
-	 * Generate new inum for group
-	 * 
-	 * @return New inum for group
-	 * @throws Exception
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#generateInumForNewGroup()
 	 */
+	@Override
 	public String generateInumForNewGroup() throws Exception {
 		GluuGroup group = new GluuGroup();
 		String newInum = null;
@@ -194,24 +176,18 @@ public class GroupService implements Serializable {
 		return newInum;
 	}
 
-	/**
-	 * Generate new iname for group
-	 * 
-	 * @return New iname for group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#generateInameForNewGroup(java.lang.String)
 	 */
+	@Override
 	public String generateInameForNewGroup(String name) throws Exception {
 		return String.format("%s*group*%s", applicationConfiguration.getOrgIname(), name);
 	}
 
-	/**
-	 * Search groups by pattern
-	 * 
-	 * @param pattern
-	 *            Pattern
-	 * @param sizeLimit
-	 *            Maximum count of results
-	 * @return List of groups
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#searchGroups(java.lang.String, int)
 	 */
+	@Override
 	public List<GluuGroup> searchGroups(String pattern, int sizeLimit) throws Exception {
 		String[] targetArray = new String[] { pattern };
 		Filter displayNameFilter = Filter.createSubstringFilter(OxTrustConstants.displayName, null, targetArray, null);
@@ -224,11 +200,10 @@ public class GroupService implements Serializable {
 		return result;
 	}
 
-	/**
-	 * Get all available visibility types
-	 * 
-	 * @return Array of visibility types
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getVisibilityTypes()
 	 */
+	@Override
 	public GluuGroupVisibility[] getVisibilityTypes() throws Exception {
 		return GluuGroupVisibility.values();
 	}
@@ -244,12 +219,11 @@ public class GroupService implements Serializable {
 				+ INumGenerator.generate(2);
 	}
 
-	/**
-	 * returns a list of all groups
-	 * 
-	 * @return list of groups
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getAllGroupsList()
 	 */
 
+	@Override
 	public List<GluuGroup> getAllGroupsList() throws Exception {
 
 		List<GluuGroup> result = ldapEntryManager
@@ -258,12 +232,11 @@ public class GroupService implements Serializable {
 		return result;
 	}
 
-	/**
-	 * returns GluuGroup by Dn
-	 * 
-	 * @return GluuGroup
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getGroupByDn(java.lang.String)
 	 */
 
+	@Override
 	public GluuGroup getGroupByDn(String Dn) {
 		GluuGroup result = ldapEntryManager.find(GluuGroup.class, Dn);
 
@@ -275,16 +248,14 @@ public class GroupService implements Serializable {
 	 * 
 	 * @return GroupService instance
 	 */
-	public static GroupService instance() {
-		return (GroupService) Component.getInstance(GroupService.class);
+	public static IGroupService instance() {
+		return (IGroupService) Component.getInstance(GroupService.class);
 	}
 
-	/**
-	 * Get Group by iname
-	 * 
-	 * @param iname
-	 * @return Group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getGroupByIname(java.lang.String)
 	 */
+	@Override
 	public GluuGroup getGroupByIname(String iname) throws Exception {
 		GluuGroup group = new GluuGroup();
 		group.setBaseDn(getDnForGroup(null));
@@ -299,12 +270,10 @@ public class GroupService implements Serializable {
 		return null;
 	}
 
-	/**
-	 * Get group by DisplayName
-	 * 
-	 * @param DisplayName
-	 * @return group
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IGroupService#getGroupByDisplayName(java.lang.String)
 	 */
+	@Override
 	public GluuGroup getGroupByDisplayName(String DisplayName) throws Exception {
 		GluuGroup group = new GluuGroup();
 		group.setBaseDn(getDnForGroup(null));

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/IGroupService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/IGroupService.java
@@ -1,0 +1,139 @@
+package org.gluu.oxtrust.ldap.service;
+
+import java.util.List;
+
+import org.gluu.oxtrust.model.GluuGroup;
+import org.gluu.oxtrust.model.GluuGroupVisibility;
+
+public interface IGroupService {
+
+	/**
+	 * Add new group entry
+	 * 
+	 * @param group
+	 *            Group
+	 */
+	public abstract void addGroup(GluuGroup group) throws Exception;
+
+	/**
+	 * Remove group entry
+	 * 
+	 * @param group
+	 *            Group
+	 */
+	public abstract void removeGroup(GluuGroup group);
+
+	/**
+	 * Get all groups
+	 * 
+	 * @return List of groups
+	 */
+	public abstract List<GluuGroup> getAllGroups();
+
+	/**
+	 * Check if person is a member or owner of specified group
+	 * 
+	 * @param groupDN
+	 *            Group DN
+	 * @param personDN
+	 *            Person DN
+	 * @return True if person is a member or owner of specified group
+	 */
+	public abstract boolean isMemberOrOwner(String groupDN, String personDN);
+
+	/**
+	 * Get group by inum
+	 * 
+	 * @param inum
+	 *            Group Inum
+	 * @return Group
+	 */
+	public abstract GluuGroup getGroupByInum(String inum);
+
+	/**
+	 * Build DN string for group
+	 * 
+	 * @param inum
+	 *            Group Inum
+	 * @return DN string for specified group or DN for groups branch if inum is
+	 *         null
+	 * @throws Exception
+	 */
+	public abstract String getDnForGroup(String inum);
+
+	/**
+	 * Update group entry
+	 * 
+	 * @param group
+	 *            Group
+	 */
+	public abstract void updateGroup(GluuGroup group) throws Exception;
+
+	public abstract int countGroups();
+
+	/**
+	 * Generate new inum for group
+	 * 
+	 * @return New inum for group
+	 * @throws Exception
+	 */
+	public abstract String generateInumForNewGroup() throws Exception;
+
+	/**
+	 * Generate new iname for group
+	 * 
+	 * @return New iname for group
+	 */
+	public abstract String generateInameForNewGroup(String name) throws Exception;
+
+	/**
+	 * Search groups by pattern
+	 * 
+	 * @param pattern
+	 *            Pattern
+	 * @param sizeLimit
+	 *            Maximum count of results
+	 * @return List of groups
+	 */
+	public abstract List<GluuGroup> searchGroups(String pattern, int sizeLimit) throws Exception;
+
+	/**
+	 * Get all available visibility types
+	 * 
+	 * @return Array of visibility types
+	 */
+	public abstract GluuGroupVisibility[] getVisibilityTypes() throws Exception;
+
+	/**
+	 * returns a list of all groups
+	 * 
+	 * @return list of groups
+	 */
+
+	public abstract List<GluuGroup> getAllGroupsList() throws Exception;
+
+	/**
+	 * returns GluuGroup by Dn
+	 * 
+	 * @return GluuGroup
+	 */
+
+	public abstract GluuGroup getGroupByDn(String Dn);
+
+	/**
+	 * Get Group by iname
+	 * 
+	 * @param iname
+	 * @return Group
+	 */
+	public abstract GluuGroup getGroupByIname(String iname) throws Exception;
+
+	/**
+	 * Get group by DisplayName
+	 * 
+	 * @param DisplayName
+	 * @return group
+	 */
+	public abstract GluuGroup getGroupByDisplayName(String DisplayName) throws Exception;
+
+}

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/IPersonService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/IPersonService.java
@@ -1,0 +1,201 @@
+package org.gluu.oxtrust.ldap.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.gluu.oxtrust.model.GluuCustomAttribute;
+import org.gluu.oxtrust.model.GluuCustomPerson;
+import org.gluu.oxtrust.model.User;
+import org.gluu.site.ldap.exception.DuplicateEntryException;
+import org.gluu.site.ldap.persistence.AttributeData;
+import org.xdi.model.GluuAttribute;
+
+public interface IPersonService {
+
+	public abstract void addCustomObjectClass(GluuCustomPerson person);
+
+	/**
+	 * Add new person
+	 * 
+	 * @param person
+	 *            Person
+	 * @throws DuplicateEntryException
+	 */
+	// TODO: Review this methods. We need to check if uid is unique in outside
+	// method
+	public abstract void addPerson(GluuCustomPerson person) throws DuplicateEntryException;
+
+	/**
+	 * Add person entry
+	 * 
+	 * @param person
+	 *            Person
+	 */
+	public abstract void updatePerson(GluuCustomPerson person);
+
+	/**
+	 * Remove person with persona and contacts branches
+	 * 
+	 * @param person
+	 *            Person
+	 */
+	public abstract void removePerson(GluuCustomPerson person);
+
+	/**
+	 * Search persons by pattern
+	 * 
+	 * @param pattern
+	 *            Pattern
+	 * @param sizeLimit
+	 *            Maximum count of results
+	 * @return List of persons
+	 */
+	public abstract List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit);
+
+	/**
+	 * Search persons by sample object
+	 * 
+	 * @param person
+	 *            Person with set attributes relevant to he current search (for
+	 *            example gluuAllowPublication)
+	 * @param sizeLimit
+	 *            Maximum count of results
+	 * @return List of persons
+	 */
+	public abstract List<GluuCustomPerson> findPersons(GluuCustomPerson person, int sizeLimit);
+
+	/**
+	 * Search persons by pattern
+	 * 
+	 * @param pattern
+	 *            Pattern
+	 * @param sizeLimit
+	 *            Maximum count of results
+	 * @param excludedPersons
+	 *            list of uids that we don't want returned by service
+	 * @return List of persons
+	 */
+	public abstract List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit, List<GluuCustomPerson> excludedPersons)
+			throws Exception;
+
+	public abstract List<GluuCustomPerson> findAllPersons(String[] returnAttributes);
+
+	public abstract List<GluuCustomPerson> findPersonsByUids(List<String> uids, String[] returnAttributes) throws Exception;
+
+	public abstract GluuCustomPerson findPersonByDn(String dn, String... returnAttributes);
+
+	/**
+	 * Check if LDAP server contains person with specified attributes
+	 * 
+	 * @return True if person with specified attributes exist
+	 */
+	public abstract boolean containsPerson(GluuCustomPerson person);
+
+	public abstract boolean contains(String dn);
+
+	/**
+	 * Get person by DN
+	 * 
+	 * @param dn
+	 *            Dn
+	 * @return Person
+	 */
+	public abstract GluuCustomPerson getPersonByDn(String dn);
+
+	/**
+	 * Get person by inum
+	 * 
+	 * @param returnClass
+	 *            POJO class which EntryManager should use to return entry
+	 *            object
+	 * @param inum
+	 *            Inum
+	 * @return Person
+	 */
+	public abstract GluuCustomPerson getPersonByInum(String inum);
+
+	/**
+	 * Get person by uid
+	 * 
+	 * @param uid
+	 *            Uid
+	 * @return Person
+	 */
+	public abstract GluuCustomPerson getPersonByUid(String uid);
+
+	public abstract int countPersons();
+
+	/**
+	 * Generate new inum for person
+	 * 
+	 * @return New inum for person
+	 */
+	public abstract String generateInumForNewPerson();
+
+	public abstract String generateInameForNewPerson(String uid);
+
+	/**
+	 * Build DN string for person
+	 * 
+	 * @param inum
+	 *            Inum
+	 * @return DN string for specified person or DN for persons branch if inum
+	 *         is null
+	 * @throws Exception
+	 */
+	public abstract String getDnForPerson(String inum);
+
+	/**
+	 * Authenticate user
+	 * 
+	 * @param userName
+	 *            User name
+	 * @param password
+	 *            User password
+	 * @return
+	 */
+	public abstract boolean authenticate(String userName, String password);
+
+	public abstract List<GluuCustomAttribute> getMandatoryAtributes();
+
+	public abstract String getPersonString(List<GluuCustomPerson> persons) throws Exception;
+
+	public abstract List<GluuCustomPerson> createEntities(Map<String, List<AttributeData>> entriesAttributes) throws Exception;
+
+	public abstract boolean isMemberOrOwner(String[] groupDNs, String personDN) throws Exception;
+
+	/**
+	 * Get person by email
+	 * 
+	 * @param email
+	 *            email
+	 * @return Person
+	 */
+	public abstract GluuCustomPerson getPersonByEmail(String email);
+
+	/**
+	 * Get person by attribute
+	 * 
+	 * @param attribute
+	 *            attribute
+	 * @param value
+	 *            value
+	 * @return Person
+	 */
+	public abstract GluuCustomPerson getPersonByAttribute(String attribute, String value) throws Exception;
+
+	/**
+	 * Remove custom attribute from all persons.
+	 */
+	public abstract void removeAttribute(GluuAttribute attribute);
+
+	/**
+	 * Get user by uid
+	 * 
+	 * @param uid
+	 *            Uid
+	 * @return User
+	 */
+	public abstract User getUserByUid(String uid);
+
+}

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/PersonService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/PersonService.java
@@ -48,7 +48,7 @@ import com.unboundid.util.StaticUtils;
 @Scope(ScopeType.STATELESS)
 @Name("personService")
 @AutoCreate
-public class PersonService implements Serializable {
+public class PersonService implements Serializable, IPersonService {
 
 	private static final long serialVersionUID = 6685720517520443399L;
 
@@ -59,7 +59,7 @@ public class PersonService implements Serializable {
 	private LdapEntryManager ldapEntryManager;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@In
 	private AttributeService attributeService;
@@ -69,6 +69,10 @@ public class PersonService implements Serializable {
 
 	private List<GluuCustomAttribute> mandatoryAttributes;
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#addCustomObjectClass(org.gluu.oxtrust.model.GluuCustomPerson)
+	 */
+	@Override
 	public void addCustomObjectClass(GluuCustomPerson person) {
 		String customObjectClass = attributeService.getCustomOrigin();
 		String[] customObjectClassesArray = person.getCustomObjectClasses();
@@ -88,15 +92,12 @@ public class PersonService implements Serializable {
 		}
 	}
 
-	/**
-	 * Add new person
-	 * 
-	 * @param person
-	 *            Person
-	 * @throws DuplicateEntryException
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#addPerson(org.gluu.oxtrust.model.GluuCustomPerson)
 	 */
 	// TODO: Review this methods. We need to check if uid is unique in outside
 	// method
+	@Override
 	public void addPerson(GluuCustomPerson person) throws DuplicateEntryException {
 		GluuCustomPerson uidPerson = new GluuCustomPerson();
 		uidPerson.setUid(person.getUid());
@@ -108,23 +109,19 @@ public class PersonService implements Serializable {
 		}
 	}
 
-	/**
-	 * Add person entry
-	 * 
-	 * @param person
-	 *            Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#updatePerson(org.gluu.oxtrust.model.GluuCustomPerson)
 	 */
+	@Override
 	public void updatePerson(GluuCustomPerson person) {
 		ldapEntryManager.merge(person);
 
 	}
 
-	/**
-	 * Remove person with persona and contacts branches
-	 * 
-	 * @param person
-	 *            Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#removePerson(org.gluu.oxtrust.model.GluuCustomPerson)
 	 */
+	@Override
 	public void removePerson(GluuCustomPerson person) {
 		// TODO: Do we realy need to remove group if owner is removed?
 		List<GluuGroup> groups = groupService.getAllGroups();
@@ -138,15 +135,10 @@ public class PersonService implements Serializable {
 		ldapEntryManager.remove(person);
 	}
 
-	/**
-	 * Search persons by pattern
-	 * 
-	 * @param pattern
-	 *            Pattern
-	 * @param sizeLimit
-	 *            Maximum count of results
-	 * @return List of persons
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#searchPersons(java.lang.String, int)
 	 */
+	@Override
 	public List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit) {
 		String[] targetArray = new String[] { pattern };
 		Filter uidFilter = Filter.createSubstringFilter(OxTrustConstants.uid, null, targetArray, null);
@@ -160,32 +152,19 @@ public class PersonService implements Serializable {
 		return result;
 	}
 
-	/**
-	 * Search persons by sample object
-	 * 
-	 * @param person
-	 *            Person with set attributes relevant to he current search (for
-	 *            example gluuAllowPublication)
-	 * @param sizeLimit
-	 *            Maximum count of results
-	 * @return List of persons
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#findPersons(org.gluu.oxtrust.model.GluuCustomPerson, int)
 	 */
+	@Override
 	public List<GluuCustomPerson> findPersons(GluuCustomPerson person, int sizeLimit) {
 		person.setBaseDn(getDnForPerson(null));
 		return ldapEntryManager.findEntries(person, sizeLimit);
 	}
 
-	/**
-	 * Search persons by pattern
-	 * 
-	 * @param pattern
-	 *            Pattern
-	 * @param sizeLimit
-	 *            Maximum count of results
-	 * @param excludedPersons
-	 *            list of uids that we don't want returned by service
-	 * @return List of persons
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#searchPersons(java.lang.String, int, java.util.List)
 	 */
+	@Override
 	public List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit, List<GluuCustomPerson> excludedPersons) throws Exception {
 		String[] targetArray = new String[] { pattern };
 		Filter uidFilter = Filter.createSubstringFilter(OxTrustConstants.uid, null, targetArray, null);
@@ -219,12 +198,20 @@ public class PersonService implements Serializable {
 
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#findAllPersons(java.lang.String[])
+	 */
+	@Override
 	public List<GluuCustomPerson> findAllPersons(String[] returnAttributes)  {
 		List<GluuCustomPerson> result = ldapEntryManager.findEntries(getDnForPerson(null), GluuCustomPerson.class, returnAttributes, null);
 
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#findPersonsByUids(java.util.List, java.lang.String[])
+	 */
+	@Override
 	public List<GluuCustomPerson> findPersonsByUids(List<String> uids, String[] returnAttributes) throws Exception {
 		List<Filter> uidFilters = new ArrayList<Filter>();
 		for (String uid : uids) {
@@ -239,32 +226,36 @@ public class PersonService implements Serializable {
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#findPersonByDn(java.lang.String, java.lang.String)
+	 */
+	@Override
 	public GluuCustomPerson findPersonByDn(String dn, String... returnAttributes) {
 		return ldapEntryManager.find(GluuCustomPerson.class, dn, returnAttributes);
 	}
 
-	/**
-	 * Check if LDAP server contains person with specified attributes
-	 * 
-	 * @return True if person with specified attributes exist
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#containsPerson(org.gluu.oxtrust.model.GluuCustomPerson)
 	 */
+	@Override
 	public boolean containsPerson(GluuCustomPerson person) {
 		boolean result = ldapEntryManager.contains(person);
 
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#contains(java.lang.String)
+	 */
+	@Override
 	public boolean contains(String dn) {
 		return ldapEntryManager.contains(GluuCustomPerson.class, dn);
 	}
 
-	/**
-	 * Get person by DN
-	 * 
-	 * @param dn
-	 *            Dn
-	 * @return Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonByDn(java.lang.String)
 	 */
+	@Override
 	public GluuCustomPerson getPersonByDn(String dn) {
 		GluuCustomPerson result = ldapEntryManager.find(GluuCustomPerson.class, dn);
 
@@ -272,16 +263,10 @@ public class PersonService implements Serializable {
 
 	}
 
-	/**
-	 * Get person by inum
-	 * 
-	 * @param returnClass
-	 *            POJO class which EntryManager should use to return entry
-	 *            object
-	 * @param inum
-	 *            Inum
-	 * @return Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonByInum(java.lang.String)
 	 */
+	@Override
 	public GluuCustomPerson getPersonByInum(String inum) {
 		GluuCustomPerson person = null;
 		try{
@@ -294,13 +279,10 @@ public class PersonService implements Serializable {
 		return person;
 	}
 
-	/**
-	 * Get person by uid
-	 * 
-	 * @param uid
-	 *            Uid
-	 * @return Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonByUid(java.lang.String)
 	 */
+	@Override
 	public GluuCustomPerson getPersonByUid(String uid) {
 		GluuCustomPerson person = new GluuCustomPerson();
 		person.setBaseDn(getDnForPerson(null));
@@ -315,6 +297,10 @@ public class PersonService implements Serializable {
 		return null;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#countPersons()
+	 */
+	@Override
 	public int countPersons() {
 		GluuCustomPerson gluuBasePerson = new GluuCustomPerson();
 		gluuBasePerson.setBaseDn(getDnForPerson(null));
@@ -322,11 +308,10 @@ public class PersonService implements Serializable {
 		return ldapEntryManager.countEntries(gluuBasePerson);
 	}
 
-	/**
-	 * Generate new inum for person
-	 * 
-	 * @return New inum for person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#generateInumForNewPerson()
 	 */
+	@Override
 	public String generateInumForNewPerson() {
 		GluuCustomPerson person = null;
 		String newInum = null;
@@ -352,6 +337,10 @@ public class PersonService implements Serializable {
 		return orgInum + OxTrustConstants.inumDelimiter + OxTrustConstants.INUM_PERSON_OBJECTTYPE + OxTrustConstants.inumDelimiter + generateInum();
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#generateInameForNewPerson(java.lang.String)
+	 */
+	@Override
 	public String generateInameForNewPerson(String uid) {
 		return String.format("%s*person*%s", applicationConfiguration.getOrgIname(), uid);
 	}
@@ -374,15 +363,10 @@ public class PersonService implements Serializable {
 		return inum;
 	}
 
-	/**
-	 * Build DN string for person
-	 * 
-	 * @param inum
-	 *            Inum
-	 * @return DN string for specified person or DN for persons branch if inum
-	 *         is null
-	 * @throws Exception
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getDnForPerson(java.lang.String)
 	 */
+	@Override
 	public String getDnForPerson(String inum) {
 		String orgDn = OrganizationService.instance().getDnForOrganization();
 		if (StringHelper.isEmpty(inum)) {
@@ -392,15 +376,10 @@ public class PersonService implements Serializable {
 		return String.format("inum=%s,ou=people,%s", inum, orgDn);
 	}
 
-	/**
-	 * Authenticate user
-	 * 
-	 * @param userName
-	 *            User name
-	 * @param password
-	 *            User password
-	 * @return
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#authenticate(java.lang.String, java.lang.String)
 	 */
+	@Override
 	public boolean authenticate(String userName, String password) {
 		boolean result = ldapEntryManager.authenticate(userName, password, applicationConfiguration.getBaseDN());
 
@@ -412,10 +391,14 @@ public class PersonService implements Serializable {
 	 * 
 	 * @return PersonService instance
 	 */
-	public static PersonService instance() {
-		return (PersonService) Component.getInstance(PersonService.class);
+	public static IPersonService instance() {
+		return (IPersonService) Component.getInstance(PersonService.class);
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getMandatoryAtributes()
+	 */
+	@Override
 	public List<GluuCustomAttribute> getMandatoryAtributes() {
 		if (this.mandatoryAttributes == null) {
 			mandatoryAttributes = new ArrayList<GluuCustomAttribute>();
@@ -429,6 +412,10 @@ public class PersonService implements Serializable {
 		return mandatoryAttributes;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonString(java.util.List)
+	 */
+	@Override
 	public String getPersonString(List<GluuCustomPerson> persons) throws Exception {
 		StringBuilder sb = new StringBuilder();
 
@@ -442,12 +429,20 @@ public class PersonService implements Serializable {
 		return sb.toString();
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#createEntities(java.util.Map)
+	 */
+	@Override
 	public List<GluuCustomPerson> createEntities(Map<String, List<AttributeData>> entriesAttributes) throws Exception {
 		List<GluuCustomPerson> result = ldapEntryManager.createEntities(GluuCustomPerson.class, entriesAttributes);
 
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#isMemberOrOwner(java.lang.String[], java.lang.String)
+	 */
+	@Override
 	public boolean isMemberOrOwner(String[] groupDNs, String personDN) throws Exception {
 		boolean result = false;
 		if (ArrayHelper.isEmpty(groupDNs)) {
@@ -468,13 +463,10 @@ public class PersonService implements Serializable {
 		return result;
 	}
 
-	/**
-	 * Get person by email
-	 * 
-	 * @param email
-	 *            email
-	 * @return Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonByEmail(java.lang.String)
 	 */
+	@Override
 	public GluuCustomPerson getPersonByEmail(String email) {
 		GluuCustomPerson person = new GluuCustomPerson();
 		person.setBaseDn(getDnForPerson(null));
@@ -489,15 +481,10 @@ public class PersonService implements Serializable {
 		return null;
 	}
 
-	/**
-	 * Get person by attribute
-	 * 
-	 * @param attribute
-	 *            attribute
-	 * @param value
-	 *            value
-	 * @return Person
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getPersonByAttribute(java.lang.String, java.lang.String)
 	 */
+	@Override
 	public GluuCustomPerson getPersonByAttribute(String attribute, String value) throws Exception {
 		GluuCustomPerson person = new GluuCustomPerson();
 		person.setBaseDn(getDnForPerson(null));
@@ -512,21 +499,19 @@ public class PersonService implements Serializable {
 		return null;
 	}
 
-	/**
-	 * Remove custom attribute from all persons.
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#removeAttribute(org.xdi.model.GluuAttribute)
 	 */
+	@Override
 	public void removeAttribute(GluuAttribute attribute) {
 		ldapEntryManager.removeAttributeFromEntries(getDnForPerson(null), GluuCustomPerson.class, attribute.getName());
 		
 	}
 
-	/**
-	 * Get user by uid
-	 * 
-	 * @param uid
-	 *            Uid
-	 * @return User
+	/* (non-Javadoc)
+	 * @see org.gluu.oxtrust.ldap.service.IPersonService#getUserByUid(java.lang.String)
 	 */
+	@Override
 	public User getUserByUid(String uid) {
 
 		User user = new User();

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/SecurityService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/SecurityService.java
@@ -38,10 +38,10 @@ public class SecurityService implements Serializable {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@In
 	private OrganizationService organizationService;

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/StatusCheckerDaily.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/StatusCheckerDaily.java
@@ -37,10 +37,10 @@ public class StatusCheckerDaily {
 	private ApplianceService applianceService;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private CentralLdapService centralLdapService;

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/StatusCheckerTimer.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/StatusCheckerTimer.java
@@ -70,10 +70,10 @@ public class StatusCheckerTimer {
 	private ApplianceService applianceService;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private CentralLdapService centralLdapService;

--- a/server/src/main/java/org/gluu/oxtrust/model/GluuCustomAttribute.java
+++ b/server/src/main/java/org/gluu/oxtrust/model/GluuCustomAttribute.java
@@ -148,7 +148,8 @@ public class GluuCustomAttribute implements Serializable, Comparable<GluuCustomA
 
 
 	public String getDisplayValue() {
-		if (values == null) {
+
+		if (values == null || values.length==0) {
 			return "";
 		}
 

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -20,6 +20,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.gluu.oxtrust.ldap.service.AttributeService;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.OrganizationService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
@@ -60,6 +62,76 @@ import org.xdi.model.GluuAttribute;
 @Name("copyUtils")
 public class CopyUtils implements Serializable {
 
+	private static final String GLUU_STATUS = "gluuStatus";
+
+	private static final String OX_TRUST_PHOTOS_TYPE = "oxTrustPhotosType";
+
+	private static final String OX_TRUST_PHONE_TYPE = "oxTrustPhoneType";
+
+	private static final String OX_TRUST_ADDRESS_PRIMARY = "oxTrustAddressPrimary";
+
+	private static final String OX_TRUST_ADDRESS_TYPE = "oxTrustAddressType";
+
+	private static final String OX_TRUST_COUNTRY = "oxTrustCountry";
+
+	private static final String OX_TRUST_POSTAL_CODE = "oxTrustPostalCode";
+
+	private static final String OX_TRUST_REGION = "oxTrustRegion";
+
+	private static final String OX_TRUST_LOCALITY = "oxTrustLocality";
+
+	private static final String OX_TRUST_ADDRESS_FORMATTED = "oxTrustAddressFormatted";
+
+	private static final String OX_TRUST_STREET = "oxTrustStreet";
+
+	private static final String OX_TRUST_EMAIL_PRIMARY = "oxTrustEmailPrimary";
+
+	private static final String OX_TRUST_EMAIL_TYPE = "oxTrustEmailType";
+
+	private static final String OX_TRUST_META_LOCATION = "oxTrustMetaLocation";
+
+	private static final String OX_TRUST_META_VERSION = "oxTrustMetaVersion";
+
+	private static final String OX_TRUST_META_LAST_MODIFIED = "oxTrustMetaLastModified";
+
+	private static final String OX_TRUST_META_CREATED = "oxTrustMetaCreated";
+
+	private static final String OX_TRUSTX509_CERTIFICATE = "oxTrustx509Certificate";
+
+	private static final String OX_TRUST_ENTITLEMENTS = "oxTrustEntitlements";
+
+	private static final String OX_TRUST_ROLE = "oxTrustRole";
+
+	private static final String OX_TRUST_ACTIVE = "oxTrustActive";
+
+	private static final String OX_TRUST_LOCALE = "oxTrustLocale";
+
+	private static final String OX_TRUST_TITLE = "oxTrustTitle";
+
+	private static final String OX_TRUST_USER_TYPE = "oxTrustUserType";
+
+	private static final String OX_TRUST_PHOTOS = "oxTrustPhotos";
+
+	private static final String OX_TRUST_IMS_VALUE = "oxTrustImsValue";
+
+	private static final String OX_TRUST_PHONE_VALUE = "oxTrustPhoneValue";
+
+	private static final String OX_TRUST_ADDRESSES = "oxTrustAddresses";
+
+	private static final String OX_TRUST_EMAIL = "oxTrustEmail";
+
+	private static final String OX_TRUST_PROFILE_URL = "oxTrustProfileURL";
+
+	private static final String OX_TRUST_NICK_NAME = "oxTrustNickName";
+
+	private static final String OX_TRUST_EXTERNAL_ID = "oxTrustExternalId";
+
+	private static final String OX_TRUSTHONORIFIC_SUFFIX = "oxTrusthonorificSuffix";
+
+	private static final String OX_TRUSTHONORIFIC_PREFIX = "oxTrusthonorificPrefix";
+
+	private static final String OX_TRUST_MIDDLE_NAME = "oxTrustMiddleName";
+
 	/**
      *
      */
@@ -82,7 +154,7 @@ public class CopyUtils implements Serializable {
 			return null;
 		}
 
-		PersonService personService1 = PersonService.instance();
+		IPersonService personService1 = PersonService.instance();
 
 		if (destination == null) {
 			log.trace(" creating a new GluuCustomPerson instant ");
@@ -110,82 +182,57 @@ public class CopyUtils implements Serializable {
 				destination.setDisplayName(source.getDisplayName());
 			}
 
-			setOrRemoveOptionalAttribute(destination, source.getName().getMiddleName(), "oxTrustMiddleName");
+			setOrRemoveOptionalAttribute(destination, source.getName().getMiddleName(), OX_TRUST_MIDDLE_NAME);
 
-			setOrRemoveOptionalAttribute(destination, source.getName().getHonorificPrefix(), "oxTrusthonorificPrefix");
+			setOrRemoveOptionalAttribute(destination, source.getName().getHonorificPrefix(), OX_TRUSTHONORIFIC_PREFIX);
 
-			setOrRemoveOptionalAttribute(destination, source.getName().getHonorificSuffix(), "oxTrusthonorificSuffix");
+			setOrRemoveOptionalAttribute(destination, source.getName().getHonorificSuffix(), OX_TRUSTHONORIFIC_SUFFIX);
 
-			setOrRemoveOptionalAttribute(destination, source.getExternalId(), "oxTrustExternalId");
+			setOrRemoveOptionalAttribute(destination, source.getExternalId(), OX_TRUST_EXTERNAL_ID);
 
-			setOrRemoveOptionalAttribute(destination, source.getNickName(), "oxTrustNickName");
+			setOrRemoveOptionalAttribute(destination, source.getNickName(), OX_TRUST_NICK_NAME);
 
-			setOrRemoveOptionalAttribute(destination, source.getProfileUrl(), "oxTrustProfileURL");
+			setOrRemoveOptionalAttribute(destination, source.getProfileUrl(), OX_TRUST_PROFILE_URL);
 
-			setOrRemoveOptionalAttributeList(destination, source.getEmails(), "oxTrustEmail");
+			setOrRemoveOptionalAttributeList(destination, source.getEmails(), OX_TRUST_EMAIL);
 
-			setOrRemoveOptionalAttributeList(destination, source.getAddresses(), "oxTrustAddresses");
+			setOrRemoveOptionalAttributeList(destination, source.getAddresses(), OX_TRUST_ADDRESSES);
 
-			setOrRemoveOptionalAttributeList(destination, source.getPhoneNumbers(), "oxTrustPhoneValue");
+			setOrRemoveOptionalAttributeList(destination, source.getPhoneNumbers(), OX_TRUST_PHONE_VALUE);
 
-			setOrRemoveOptionalAttributeList(destination, source.getIms(), "oxTrustImsValue");
+			setOrRemoveOptionalAttributeList(destination, source.getIms(), OX_TRUST_IMS_VALUE);
 
-			setOrRemoveOptionalAttributeList(destination, source.getPhotos(), "oxTrustPhotos");
+			setOrRemoveOptionalAttributeList(destination, source.getPhotos(), OX_TRUST_PHOTOS);
 
-			setOrRemoveOptionalAttribute(destination, source.getUserType(), "oxTrustUserType");
+			setOrRemoveOptionalAttribute(destination, source.getUserType(), OX_TRUST_USER_TYPE);
 
-			setOrRemoveOptionalAttribute(destination, source.getTitle(), "oxTrustTitle");
+			setOrRemoveOptionalAttribute(destination, source.getTitle(), OX_TRUST_TITLE);
 
 			if (source.getPreferredLanguage() != null && source.getPreferredLanguage().length() > 0) {
 				destination.setPreferredLanguage(source.getPreferredLanguage());
 			}
 
-			setOrRemoveOptionalAttribute(destination, source.getLocale(), "oxTrustLocale");
+			setOrRemoveOptionalAttribute(destination, source.getLocale(), OX_TRUST_LOCALE);
 
 			if (source.getTimezone() != null && source.getTimezone().length() > 0) {
 				destination.setTimezone(source.getTimezone());
 			}
 
-			setOrRemoveOptionalAttribute(destination, source.getActive(), "oxTrustActive");
+			setOrRemoveOptionalAttribute(destination, source.getActive(), OX_TRUST_ACTIVE);
 
 			if (StringUtils.isNotEmpty(source.getPassword())) {
 				destination.setUserPassword(source.getPassword());
 			}
 
-			// getting user groups
-			log.trace(" setting groups ");
-			if (source.getGroups() != null && source.getGroups().size() > 0) {
-				GroupService groupService = GroupService.instance();
-				List<ScimPersonGroups> listGroups = source.getGroups();
-				List<String> members = new ArrayList<String>();
-				for (ScimPersonGroups group : listGroups) {
+			setGroups(source, destination);
 
-					members.add(groupService.getDnForGroup(group.getValue()));
-				}
-				destination.setMemberOf(members);
-			}
+			setOrRemoveOptionalAttributeList(destination, source.getRoles(), OX_TRUST_ROLE);
 
-			setOrRemoveOptionalAttributeList(destination, source.getRoles(), "oxTrustRole");
+			setOrRemoveOptionalAttributeList(destination, source.getEntitlements(), OX_TRUST_ENTITLEMENTS);
 
-			setOrRemoveOptionalAttributeList(destination, source.getEntitlements(), "oxTrustEntitlements");
+			setOrRemoveOptionalAttributeList(destination, source.getX509Certificates(), OX_TRUSTX509_CERTIFICATE);
 
-			setOrRemoveOptionalAttributeList(destination, source.getX509Certificates(), "oxTrustx509Certificate");
-
-			// getting meta
-			log.trace(" setting meta ");
-
-			if (source.getMeta().getCreated() != null && source.getMeta().getCreated().length() > 0) {
-				destination.setAttribute("oxTrustMetaCreated", source.getMeta().getCreated());
-			}
-			if (source.getMeta().getLastModified() != null && source.getMeta().getLastModified().length() > 0) {
-				destination.setAttribute("oxTrustMetaLastModified", source.getMeta().getLastModified());
-			}
-			if (source.getMeta().getVersion() != null && source.getMeta().getVersion().length() > 0) {
-				destination.setAttribute("oxTrustMetaVersion", source.getMeta().getVersion());
-			}
-			if (source.getMeta().getLocation() != null && source.getMeta().getLocation().length() > 0) {
-				destination.setAttribute("oxTrustMetaLocation", source.getMeta().getLocation());
-			}
+			setMetaData(source, destination);
 
 			// getting customAttributes
 			log.trace("getting custom attributes");
@@ -195,7 +242,7 @@ public class CopyUtils implements Serializable {
 				log.trace("getting a list of ScimCustomAttributes");
 
 				List<ScimCustomAttributes> customAttr = source.getCustomAttributes();
-				log.trace("checling every attribute in the request");
+				log.trace("checking every attribute in the request");
 
 				for (ScimCustomAttributes oneAttr : customAttr) {
 					if (oneAttr == null) {
@@ -249,183 +296,63 @@ public class CopyUtils implements Serializable {
 				if (source.getName().getFamilyName() != null && source.getName().getFamilyName().length() > 0) {
 					destination.setSurname(source.getName().getFamilyName());
 				}
-				log.trace(" setting middlename ");
-				if (source.getName().getMiddleName() != null && source.getName().getMiddleName().length() > 0) {
-					destination.setAttribute("oxTrustMiddleName", source.getName().getMiddleName());
-				}
-				log.trace(" setting honor");
-				if (source.getName().getHonorificPrefix() != null && source.getName().getHonorificPrefix().length() > 0) {
-					destination.setAttribute("oxTrusthonorificPrefix", source.getName().getHonorificPrefix());
-				}
-				if (source.getName().getHonorificSuffix() != null && source.getName().getHonorificSuffix().length() > 0) {
-					destination.setAttribute("oxTrusthonorificSuffix", source.getName().getHonorificSuffix());
-				}
 				log.trace(" setting displayname ");
 				if (source.getDisplayName() != null && source.getDisplayName().length() > 0) {
 					destination.setDisplayName(source.getDisplayName());
 				}
-				log.trace(" setting externalID ");
-				if (source.getExternalId() != null && source.getExternalId().length() > 0) {
-					destination.setAttribute("oxTrustExternalId", source.getExternalId());
-				}
-				log.trace(" setting nickname ");
-				if (source.getNickName() != null && source.getNickName().length() > 0) {
-					destination.setAttribute("oxTrustNickName", source.getNickName());
-				}
-				log.trace(" setting profileURL ");
-				if (source.getProfileUrl() != null && source.getProfileUrl().length() > 0) {
-					destination.setAttribute("oxTrustProfileURL", source.getProfileUrl());
-				}
+				
+				setOrRemoveOptionalAttribute(destination, source.getName().getMiddleName(), OX_TRUST_MIDDLE_NAME);
 
-				// getting emails
-				log.trace(" setting emails ");
-				if (source.getEmails() != null && source.getEmails().size() > 0) {
-					List<ScimPersonEmails> emails = source.getEmails();
-					StringWriter listOfEmails = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfEmails, emails);
+				setOrRemoveOptionalAttribute(destination, source.getName().getHonorificPrefix(), OX_TRUSTHONORIFIC_PREFIX);
 
-					destination.setAttribute("oxTrustEmail", listOfEmails.toString());
+				setOrRemoveOptionalAttribute(destination, source.getName().getHonorificSuffix(), OX_TRUSTHONORIFIC_SUFFIX);
 
-				}
+				setOrRemoveOptionalAttribute(destination, source.getExternalId(), OX_TRUST_EXTERNAL_ID);
 
-				// getting addresses
-				log.trace(" setting addresses ");
-				if (source.getAddresses() != null && source.getAddresses().size() > 0) {
-					List<ScimPersonAddresses> addresses = source.getAddresses();
+				setOrRemoveOptionalAttribute(destination, source.getNickName(), OX_TRUST_NICK_NAME);
 
-					StringWriter listOfAddresses = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfAddresses, addresses);
+				setOrRemoveOptionalAttribute(destination, source.getProfileUrl(), OX_TRUST_PROFILE_URL);
 
-					destination.setAttribute("oxTrustAddresses", listOfAddresses.toString());
-				}
+				setOrRemoveOptionalAttributeList(destination, source.getEmails(), OX_TRUST_EMAIL);
 
-				// getting phone numbers;
-				log.trace(" setting phoneNumbers ");
-				if (source.getPhoneNumbers() != null && source.getPhoneNumbers().size() > 0) {
-					List<ScimPersonPhones> phones = source.getPhoneNumbers();
+				setOrRemoveOptionalAttributeList(destination, source.getAddresses(), OX_TRUST_ADDRESSES);
 
-					StringWriter listOfPhones = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfPhones, phones);
+				setOrRemoveOptionalAttributeList(destination, source.getPhoneNumbers(), OX_TRUST_PHONE_VALUE);
 
-					destination.setAttribute("oxTrustPhoneValue", listOfPhones.toString());
-				}
+				setOrRemoveOptionalAttributeList(destination, source.getIms(), OX_TRUST_IMS_VALUE);
 
-				// getting ims
-				log.trace(" setting ims ");
-				if (source.getIms() != null && source.getIms().size() > 0) {
+				setOrRemoveOptionalAttributeList(destination, source.getPhotos(), OX_TRUST_PHOTOS);
 
-					List<ScimPersonIms> ims = source.getIms();
+				setOrRemoveOptionalAttribute(destination, source.getUserType(), OX_TRUST_USER_TYPE);
 
-					StringWriter listOfIms = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfIms, ims);
+				setOrRemoveOptionalAttribute(destination, source.getTitle(), OX_TRUST_TITLE);
 
-					destination.setAttribute("oxTrustImsValue", listOfIms.toString());
-				}
-
-				// getting Photos
-				log.trace(" setting photos ");
-				if (source.getPhotos() != null && source.getPhotos().size() > 0) {
-
-					List<ScimPersonPhotos> photos = source.getPhotos();
-
-					StringWriter listOfPhotos = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfPhotos, photos);
-
-					destination.setAttribute("oxTrustPhotos", listOfPhotos.toString());
-				}
-
-				if (source.getUserType() != null && source.getUserType().length() > 0) {
-					destination.setAttribute("oxTrustUserType", source.getUserType());
-				}
-				if (source.getTitle() != null && source.getTitle().length() > 0) {
-					destination.setAttribute("oxTrustTitle", source.getTitle());
-				}
 				if (source.getPreferredLanguage() != null && source.getPreferredLanguage().length() > 0) {
 					destination.setPreferredLanguage(source.getPreferredLanguage());
 				}
-				if (source.getLocale() != null && source.getLocale().length() > 0) {
-					destination.setAttribute("oxTrustLocale", source.getLocale());
-				}
+
+				setOrRemoveOptionalAttribute(destination, source.getLocale(), OX_TRUST_LOCALE);
+
 				if (source.getTimezone() != null && source.getTimezone().length() > 0) {
 					destination.setTimezone(source.getTimezone());
 				}
-				if (source.getActive() != null && source.getActive().length() > 0) {
-					destination.setAttribute("oxTrustActive", source.getActive());
-				}
+				
+				setOrRemoveOptionalAttribute(destination, source.getActive(), OX_TRUST_ACTIVE);
+				
 				if (source.getPassword() != null && source.getPassword().length() > 0) {
 					destination.setUserPassword(source.getPassword());
 				}
 
-				// getting user groups
-				log.trace(" setting groups ");
-				if (source.getGroups() != null && source.getGroups().size() > 0) {
-					GroupService groupService = GroupService.instance();
-					List<ScimPersonGroups> listGroups = source.getGroups();
-					List<String> members = new ArrayList<String>();
-					for (ScimPersonGroups group : listGroups) {
+				setGroups(source, destination);
 
-						members.add(groupService.getDnForGroup(group.getValue()));
-					}
-					destination.setMemberOf(members);
-				}
+				setOrRemoveOptionalAttributeList(destination, source.getRoles(), OX_TRUST_ROLE);
 
-				// getting roles
+				setOrRemoveOptionalAttributeList(destination, source.getEntitlements(), OX_TRUST_ENTITLEMENTS);
 
-				log.trace(" setting roles ");
-				if (source.getRoles() != null && source.getRoles().size() > 0) {
-					List<ScimRoles> roles = source.getRoles();
+				setOrRemoveOptionalAttributeList(destination, source.getX509Certificates(), OX_TRUSTX509_CERTIFICATE);
 
-					StringWriter listOfRoles = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfRoles, roles);
-
-					destination.setAttribute("oxTrustRole", listOfRoles.toString());
-				}
-
-				// getting entitlements
-				log.trace(" setting entilements ");
-				if (source.getEntitlements() != null && source.getEntitlements().size() > 0) {
-					List<ScimEntitlements> ents = source.getEntitlements();
-
-					StringWriter listOfEnts = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfEnts, ents);
-
-					destination.setAttribute("oxTrustEntitlements", listOfEnts.toString());
-				}
-
-				// getting x509Certificates
-				log.trace(" setting certs ");
-				if (source.getX509Certificates() != null && source.getX509Certificates().size() > 0) {
-					List<Scimx509Certificates> certs = source.getX509Certificates();
-
-					StringWriter listOfCerts = new StringWriter();
-					ObjectMapper mapper = new ObjectMapper();
-					mapper.writeValue(listOfCerts, certs);
-
-					destination.setAttribute("oxTrustx509Certificate", listOfCerts.toString());
-				}
-
-				// getting meta
-				log.trace(" setting meta ");
-
-				if (source.getMeta().getCreated() != null && source.getMeta().getCreated().length() > 0) {
-					destination.setAttribute("oxTrustMetaCreated", source.getMeta().getCreated());
-				}
-				if (source.getMeta().getLastModified() != null && source.getMeta().getLastModified().length() > 0) {
-					destination.setAttribute("oxTrustMetaLastModified", source.getMeta().getLastModified());
-				}
-				if (source.getMeta().getVersion() != null && source.getMeta().getVersion().length() > 0) {
-					destination.setAttribute("oxTrustMetaVersion", source.getMeta().getVersion());
-				}
-				if (source.getMeta().getLocation() != null && source.getMeta().getLocation().length() > 0) {
-					destination.setAttribute("oxTrustMetaLocation", source.getMeta().getLocation());
-				}
+				
+				setMetaData(source, destination);
 
 				// getting customAttributes
 				log.trace("getting custom attributes");
@@ -435,7 +362,7 @@ public class CopyUtils implements Serializable {
 					log.trace("getting a list of ScimCustomAttributes");
 
 					List<ScimCustomAttributes> customAttr = source.getCustomAttributes();
-					log.trace("checling every attribute in the request");
+					log.trace("checking every attribute in the request");
 
 					for (ScimCustomAttributes oneAttr : customAttr) {
 						if (oneAttr != null && oneAttr.getValues().size() == 1) {
@@ -469,6 +396,37 @@ public class CopyUtils implements Serializable {
 		setGluuStatus(source, destination);
 
 		return destination;
+	}
+
+	private static void setGroups(ScimPerson source, GluuCustomPerson destination) {
+		log.trace(" setting groups ");
+		if (source.getGroups() != null && source.getGroups().size() > 0) {
+			IGroupService groupService = GroupService.instance();
+			List<ScimPersonGroups> listGroups = source.getGroups();
+			List<String> members = new ArrayList<String>();
+			for (ScimPersonGroups group : listGroups) {
+
+				members.add(groupService.getDnForGroup(group.getValue()));
+			}
+			destination.setMemberOf(members);
+		}
+	}
+
+	private static void setMetaData(ScimPerson source, GluuCustomPerson destination) {
+		log.trace(" setting meta ");
+
+		if (source.getMeta().getCreated() != null && source.getMeta().getCreated().length() > 0) {
+			destination.setAttribute(OX_TRUST_META_CREATED, source.getMeta().getCreated());
+		}
+		if (source.getMeta().getLastModified() != null && source.getMeta().getLastModified().length() > 0) {
+			destination.setAttribute(OX_TRUST_META_LAST_MODIFIED, source.getMeta().getLastModified());
+		}
+		if (source.getMeta().getVersion() != null && source.getMeta().getVersion().length() > 0) {
+			destination.setAttribute(OX_TRUST_META_VERSION, source.getMeta().getVersion());
+		}
+		if (source.getMeta().getLocation() != null && source.getMeta().getLocation().length() > 0) {
+			destination.setAttribute(OX_TRUST_META_LOCATION, source.getMeta().getLocation());
+		}
 	}
 
 	private static void setOrRemoveOptionalAttributeList(GluuCustomPerson destination, List<?> items, String attributeName)
@@ -524,8 +482,8 @@ public class CopyUtils implements Serializable {
 			destination.setUserName(source.getUid());
 		}
 		log.trace(" setting ExternalID ");
-		if (source.getAttribute("oxTrustExternalId") != null) {
-			destination.setExternalId(source.getAttribute("oxTrustExternalId"));
+		if (source.getAttribute(OX_TRUST_EXTERNAL_ID) != null) {
+			destination.setExternalId(source.getAttribute(OX_TRUST_EXTERNAL_ID));
 		}
 		log.trace(" setting givenname ");
 		if (source.getGivenName() != null) {
@@ -536,18 +494,18 @@ public class CopyUtils implements Serializable {
 			destination.getName().setFamilyName(source.getSurname());
 		}
 		log.trace(" getting middlename ");
-		if (source.getAttribute("oxTrustMiddleName") != null) {
-			destination.getName().setMiddleName(source.getAttribute("oxTrustMiddleName"));
+		if (source.getAttribute(OX_TRUST_MIDDLE_NAME) != null) {
+			destination.getName().setMiddleName(source.getAttribute(OX_TRUST_MIDDLE_NAME));
 		}
 		;
 		log.trace(" getting honorificPrefix ");
-		if (source.getAttribute("oxTrusthonorificPrefix") != null) {
-			destination.getName().setHonorificPrefix(source.getAttribute("oxTrusthonorificPrefix"));
+		if (source.getAttribute(OX_TRUSTHONORIFIC_PREFIX) != null) {
+			destination.getName().setHonorificPrefix(source.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
 		}
 		;
 		log.trace(" getting honorificSuffix ");
-		if (source.getAttribute("oxTrusthonorificSuffix") != null) {
-			destination.getName().setHonorificSuffix(source.getAttribute("oxTrusthonorificSuffix"));
+		if (source.getAttribute(OX_TRUSTHONORIFIC_SUFFIX) != null) {
+			destination.getName().setHonorificSuffix(source.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
 		}
 		;
 		log.trace(" getting displayname ");
@@ -555,19 +513,19 @@ public class CopyUtils implements Serializable {
 			destination.setDisplayName(source.getDisplayName());
 		}
 		log.trace(" getting nickname ");
-		if (source.getAttribute("oxTrustNickName") != null) {
-			destination.setNickName(source.getAttribute("oxTrustNickName"));
+		if (source.getAttribute(OX_TRUST_NICK_NAME) != null) {
+			destination.setNickName(source.getAttribute(OX_TRUST_NICK_NAME));
 		}
 		log.trace(" getting profileURL ");
-		if (source.getAttribute("oxTrustProfileURL") != null) {
-			destination.setProfileUrl(source.getAttribute("oxTrustProfileURL"));
+		if (source.getAttribute(OX_TRUST_PROFILE_URL) != null) {
+			destination.setProfileUrl(source.getAttribute(OX_TRUST_PROFILE_URL));
 		}
 
 		log.trace(" getting emails ");
 		// getting emails
-		if (source.getAttribute("oxTrustEmail") != null) {
+		if (source.getAttribute(OX_TRUST_EMAIL) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimPersonEmails> listOfEmails = mapper.readValue(source.getAttribute("oxTrustEmail"),
+			List<ScimPersonEmails> listOfEmails = mapper.readValue(source.getAttribute(OX_TRUST_EMAIL),
 					new TypeReference<List<ScimPersonEmails>>() {
 					});
 			/*
@@ -588,9 +546,9 @@ public class CopyUtils implements Serializable {
 		log.trace(" getting addresses ");
 		// getting addresses
 
-		if (source.getAttribute("oxTrustAddresses") != null) {
+		if (source.getAttribute(OX_TRUST_ADDRESSES) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimPersonAddresses> listOfAddresses = mapper.readValue(source.getAttribute("oxTrustAddresses"),
+			List<ScimPersonAddresses> listOfAddresses = mapper.readValue(source.getAttribute(OX_TRUST_ADDRESSES),
 					new TypeReference<List<ScimPersonAddresses>>() {
 					});
 
@@ -644,9 +602,9 @@ public class CopyUtils implements Serializable {
 		}
 		log.trace(" setting phoneNumber ");
 		// getting user's PhoneNumber
-		if (source.getAttribute("oxTrustPhoneValue") != null) {
+		if (source.getAttribute(OX_TRUST_PHONE_VALUE) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimPersonPhones> listOfPhones = mapper.readValue(source.getAttribute("oxTrustPhoneValue"),
+			List<ScimPersonPhones> listOfPhones = mapper.readValue(source.getAttribute(OX_TRUST_PHONE_VALUE),
 					new TypeReference<List<ScimPersonPhones>>() {
 					});
 
@@ -672,9 +630,9 @@ public class CopyUtils implements Serializable {
 
 		log.trace(" getting ims ");
 		// getting ims
-		if (source.getAttribute("oxTrustImsValue") != null) {
+		if (source.getAttribute(OX_TRUST_IMS_VALUE) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimPersonIms> listOfIms = mapper.readValue(source.getAttribute("oxTrustImsValue"),
+			List<ScimPersonIms> listOfIms = mapper.readValue(source.getAttribute(OX_TRUST_IMS_VALUE),
 					new TypeReference<List<ScimPersonIms>>() {
 					});
 
@@ -692,9 +650,9 @@ public class CopyUtils implements Serializable {
 		log.trace(" setting photos ");
 		// getting photos
 
-		if (source.getAttribute("oxTrustPhotos") != null) {
+		if (source.getAttribute(OX_TRUST_PHOTOS) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimPersonPhotos> listOfPhotos = mapper.readValue(source.getAttribute("oxTrustPhotos"),
+			List<ScimPersonPhotos> listOfPhotos = mapper.readValue(source.getAttribute(OX_TRUST_PHOTOS),
 					new TypeReference<List<ScimPersonPhotos>>() {
 					});
 
@@ -715,16 +673,16 @@ public class CopyUtils implements Serializable {
 			destination.setPhotos(listOfPhotos);
 		}
 		log.trace(" setting userType ");
-		if (source.getAttribute("oxTrustUserType") != null) {
-			destination.setUserType(source.getAttribute("oxTrustUserType"));
+		if (source.getAttribute(OX_TRUST_USER_TYPE) != null) {
+			destination.setUserType(source.getAttribute(OX_TRUST_USER_TYPE));
 		}
 		log.trace(" setting title ");
-		if (source.getAttribute("oxTrustTitle") != null) {
-			destination.setTitle(source.getAttribute("oxTrustTitle"));
+		if (source.getAttribute(OX_TRUST_TITLE) != null) {
+			destination.setTitle(source.getAttribute(OX_TRUST_TITLE));
 		}
 		log.trace(" setting Locale ");
-		if (source.getAttribute("oxTrustLocale") != null) {
-			destination.setLocale(source.getAttribute("oxTrustLocale"));
+		if (source.getAttribute(OX_TRUST_LOCALE) != null) {
+			destination.setLocale(source.getAttribute(OX_TRUST_LOCALE));
 		}
 		log.trace(" setting preferredLanguage ");
 		if (source.getPreferredLanguage() != null) {
@@ -735,8 +693,8 @@ public class CopyUtils implements Serializable {
 			destination.setTimezone(source.getTimezone());
 		}
 		log.trace(" setting active ");
-		if (source.getAttribute("oxTrustActive") != null) {
-			destination.setActive(source.getAttribute("oxTrustActive"));
+		if (source.getAttribute(OX_TRUST_ACTIVE) != null) {
+			destination.setActive(source.getAttribute(OX_TRUST_ACTIVE));
 		}
 		log.trace(" setting password ");
 		destination.setPassword("Hidden for Privacy Reasons");
@@ -744,7 +702,7 @@ public class CopyUtils implements Serializable {
 		// getting user groups
 		log.trace(" setting  groups ");
 		if (source.getMemberOf() != null) {
-			GroupService groupService = GroupService.instance();
+			IGroupService groupService = GroupService.instance();
 
 			List<String> listOfGroups = source.getMemberOf();
 
@@ -761,9 +719,9 @@ public class CopyUtils implements Serializable {
 		}
 
 		// getting roles
-		if (source.getAttribute("oxTrustRole") != null) {
+		if (source.getAttribute(OX_TRUST_ROLE) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimRoles> listOfRoles = mapper.readValue(source.getAttribute("oxTrustRole"),
+			List<ScimRoles> listOfRoles = mapper.readValue(source.getAttribute(OX_TRUST_ROLE),
 					new TypeReference<List<ScimRoles>>() {
 					});
 
@@ -779,9 +737,9 @@ public class CopyUtils implements Serializable {
 		}
 		log.trace(" getting entilements ");
 		// getting entitlements
-		if (source.getAttribute("oxTrustEntitlements") != null) {
+		if (source.getAttribute(OX_TRUST_ENTITLEMENTS) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<ScimEntitlements> listOfEnts = mapper.readValue(source.getAttribute("oxTrustEntitlements"),
+			List<ScimEntitlements> listOfEnts = mapper.readValue(source.getAttribute(OX_TRUST_ENTITLEMENTS),
 					new TypeReference<List<ScimEntitlements>>() {
 					});
 
@@ -801,9 +759,9 @@ public class CopyUtils implements Serializable {
 
 		// getting x509Certificates
 		log.trace(" setting certs ");
-		if (source.getAttribute("oxTrustx509Certificate") != null) {
+		if (source.getAttribute(OX_TRUSTX509_CERTIFICATE) != null) {
 			ObjectMapper mapper = new ObjectMapper();
-			List<Scimx509Certificates> listOfCerts = mapper.readValue(source.getAttribute("oxTrustx509Certificate"),
+			List<Scimx509Certificates> listOfCerts = mapper.readValue(source.getAttribute(OX_TRUSTX509_CERTIFICATE),
 					new TypeReference<List<Scimx509Certificates>>() {
 					});
 
@@ -823,17 +781,17 @@ public class CopyUtils implements Serializable {
 		}
 		log.trace(" setting meta ");
 		// getting meta data
-		if (source.getAttribute("oxTrustMetaCreated") != null) {
-			destination.getMeta().setCreated(source.getAttribute("oxTrustMetaCreated"));
+		if (source.getAttribute(OX_TRUST_META_CREATED) != null) {
+			destination.getMeta().setCreated(source.getAttribute(OX_TRUST_META_CREATED));
 		}
-		if (source.getAttribute("oxTrustMetaLastModified") != null) {
-			destination.getMeta().setLastModified(source.getAttribute("oxTrustMetaLastModified"));
+		if (source.getAttribute(OX_TRUST_META_LAST_MODIFIED) != null) {
+			destination.getMeta().setLastModified(source.getAttribute(OX_TRUST_META_LAST_MODIFIED));
 		}
-		if (source.getAttribute("oxTrustMetaVersion") != null) {
-			destination.getMeta().setVersion(source.getAttribute("oxTrustMetaVersion"));
+		if (source.getAttribute(OX_TRUST_META_VERSION) != null) {
+			destination.getMeta().setVersion(source.getAttribute(OX_TRUST_META_VERSION));
 		}
-		if (source.getAttribute("oxTrustMetaLocation") != null) {
-			destination.getMeta().setLocation(source.getAttribute("oxTrustMetaLocation"));
+		if (source.getAttribute(OX_TRUST_META_LOCATION) != null) {
+			destination.getMeta().setLocation(source.getAttribute(OX_TRUST_META_LOCATION));
 		}
 		log.trace(" getting custom Attributes ");
 		// getting custom Attributes
@@ -918,7 +876,7 @@ public class CopyUtils implements Serializable {
 		if (destination == null) {
 			destination = new ScimGroup();
 		}
-		PersonService personService = PersonService.instance();
+		IPersonService personService = PersonService.instance();
 
 		List<String> schemas = new ArrayList<String>();
 		schemas.add("urn:scim2:schemas:core:1.0");
@@ -971,14 +929,14 @@ public class CopyUtils implements Serializable {
 		}
 		log.trace(" setting middlename ");
 		if (source.getName().getMiddleName() != null && source.getName().getMiddleName().length() > 0) {
-			destination.setAttribute("oxTrustMiddleName", source.getName().getMiddleName());
+			destination.setAttribute(OX_TRUST_MIDDLE_NAME, source.getName().getMiddleName());
 		}
 		log.trace(" setting honor");
 		if (source.getName().getHonorificPrefix() != null && source.getName().getHonorificPrefix().length() > 0) {
-			destination.setAttribute("oxTrusthonorificPrefix", source.getName().getHonorificPrefix());
+			destination.setAttribute(OX_TRUSTHONORIFIC_PREFIX, source.getName().getHonorificPrefix());
 		}
 		if (source.getName().getHonorificSuffix() != null && source.getName().getHonorificSuffix().length() > 0) {
-			destination.setAttribute("oxTrusthonorificSuffix", source.getName().getHonorificSuffix());
+			destination.setAttribute(OX_TRUSTHONORIFIC_SUFFIX, source.getName().getHonorificSuffix());
 		}
 		log.trace(" setting displayname ");
 		if (source.getDisplayName() != null && source.getDisplayName().length() > 0) {
@@ -986,15 +944,15 @@ public class CopyUtils implements Serializable {
 		}
 		log.trace(" setting externalID ");
 		if (source.getExternalId() != null && source.getExternalId().length() > 0) {
-			destination.setAttribute("oxTrustExternalId", source.getExternalId());
+			destination.setAttribute(OX_TRUST_EXTERNAL_ID, source.getExternalId());
 		}
 		log.trace(" setting nickname ");
 		if (source.getNickName() != null && source.getNickName().length() > 0) {
-			destination.setAttribute("oxTrustNickName", source.getNickName());
+			destination.setAttribute(OX_TRUST_NICK_NAME, source.getNickName());
 		}
 		log.trace(" setting profileURL ");
 		if (source.getProfileUrl() != null && source.getProfileUrl().length() > 0) {
-			destination.setAttribute("oxTrustProfileURL", source.getProfileUrl());
+			destination.setAttribute(OX_TRUST_PROFILE_URL, source.getProfileUrl());
 		}
 
 		// getting emails
@@ -1006,10 +964,10 @@ public class CopyUtils implements Serializable {
 			String[] emailsPrimary = new String[source.getEmails().size()];
 
 			int emailsSize = 0;
-			if (destination.getAttributes("oxTrustEmail") != null && destination.getAttributes("oxTrustEmail").length > 0) {
-				emailsList = destination.getAttributes("oxTrustEmail");
-				emailsTypes = destination.getAttributes("oxTrustEmailType");
-				emailsPrimary = destination.getAttributes("oxTrustEmailPrimary");
+			if (destination.getAttributes(OX_TRUST_EMAIL) != null && destination.getAttributes(OX_TRUST_EMAIL).length > 0) {
+				emailsList = destination.getAttributes(OX_TRUST_EMAIL);
+				emailsTypes = destination.getAttributes(OX_TRUST_EMAIL_TYPE);
+				emailsPrimary = destination.getAttributes(OX_TRUST_EMAIL_PRIMARY);
 				// emailsSize =
 				// destination.getAttributes("oxTrustEmail").length;
 			}
@@ -1061,9 +1019,9 @@ public class CopyUtils implements Serializable {
 				}
 			}
 
-			destination.setAttribute("oxTrustEmail", emailsList);
-			destination.setAttribute("oxTrustEmailType", emailsTypes);
-			destination.setAttribute("oxTrustEmailPrimary", emailsPrimary);
+			destination.setAttribute(OX_TRUST_EMAIL, emailsList);
+			destination.setAttribute(OX_TRUST_EMAIL_TYPE, emailsTypes);
+			destination.setAttribute(OX_TRUST_EMAIL_PRIMARY, emailsPrimary);
 		}
 
 		// getting addresses
@@ -1081,15 +1039,15 @@ public class CopyUtils implements Serializable {
 
 			int addressSize = 0;
 
-			if (destination.getAttributes("oxTrustStreet") != null && destination.getAttributes("oxTrustStreet").length > 0) {
-				street = destination.getAttributes("oxTrustStreet");
-				formatted = destination.getAttributes("oxTrustAddressFormatted");
-				locality = destination.getAttributes("oxTrustLocality");
-				region = destination.getAttributes("oxTrustRegion");
-				postalCode = destination.getAttributes("oxTrustPostalCode");
-				country = destination.getAttributes("oxTrustCountry");
-				addressType = destination.getAttributes("oxTrustAddressType");
-				addressPrimary = destination.getAttributes("oxTrustAddressPrimary");
+			if (destination.getAttributes(OX_TRUST_STREET) != null && destination.getAttributes(OX_TRUST_STREET).length > 0) {
+				street = destination.getAttributes(OX_TRUST_STREET);
+				formatted = destination.getAttributes(OX_TRUST_ADDRESS_FORMATTED);
+				locality = destination.getAttributes(OX_TRUST_LOCALITY);
+				region = destination.getAttributes(OX_TRUST_REGION);
+				postalCode = destination.getAttributes(OX_TRUST_POSTAL_CODE);
+				country = destination.getAttributes(OX_TRUST_COUNTRY);
+				addressType = destination.getAttributes(OX_TRUST_ADDRESS_TYPE);
+				addressPrimary = destination.getAttributes(OX_TRUST_ADDRESS_PRIMARY);
 				// addressSize =
 				// destination.getAttributes("oxTrustStreet").length;
 			}
@@ -1124,14 +1082,14 @@ public class CopyUtils implements Serializable {
 				addressSize++;
 			}
 
-			destination.setAttribute("oxTrustStreet", street);
-			destination.setAttribute("oxTrustLocality", locality);
-			destination.setAttribute("oxTrustRegion", region);
-			destination.setAttribute("oxTrustPostalCode", postalCode);
-			destination.setAttribute("oxTrustCountry", country);
-			destination.setAttribute("oxTrustAddressFormatted", formatted);
-			destination.setAttribute("oxTrustAddressPrimary", addressPrimary);
-			destination.setAttribute("oxTrustAddressType", addressType);
+			destination.setAttribute(OX_TRUST_STREET, street);
+			destination.setAttribute(OX_TRUST_LOCALITY, locality);
+			destination.setAttribute(OX_TRUST_REGION, region);
+			destination.setAttribute(OX_TRUST_POSTAL_CODE, postalCode);
+			destination.setAttribute(OX_TRUST_COUNTRY, country);
+			destination.setAttribute(OX_TRUST_ADDRESS_FORMATTED, formatted);
+			destination.setAttribute(OX_TRUST_ADDRESS_PRIMARY, addressPrimary);
+			destination.setAttribute(OX_TRUST_ADDRESS_TYPE, addressType);
 		}
 
 		// getting phone numbers;
@@ -1143,9 +1101,9 @@ public class CopyUtils implements Serializable {
 
 			int phoneSize = 0;
 
-			if (destination.getAttributes("oxTrustPhoneValue") != null && destination.getAttributes("oxTrustPhoneValue").length > 0) {
-				phoneNumber = destination.getAttributes("oxTrustPhoneValue");
-				phoneType = destination.getAttributes("oxTrustPhoneType");
+			if (destination.getAttributes(OX_TRUST_PHONE_VALUE) != null && destination.getAttributes(OX_TRUST_PHONE_VALUE).length > 0) {
+				phoneNumber = destination.getAttributes(OX_TRUST_PHONE_VALUE);
+				phoneType = destination.getAttributes(OX_TRUST_PHONE_TYPE);
 				// phoneSize =
 				// destination.getAttributes("oxTrustPhoneValue").length;
 			}
@@ -1159,8 +1117,8 @@ public class CopyUtils implements Serializable {
 				}
 				phoneSize++;
 			}
-			destination.setAttribute("oxTrustPhoneValue", phoneNumber);
-			destination.setAttribute("oxTrustPhoneType", phoneType);
+			destination.setAttribute(OX_TRUST_PHONE_VALUE, phoneNumber);
+			destination.setAttribute(OX_TRUST_PHONE_TYPE, phoneType);
 		}
 
 		// getting ims
@@ -1171,10 +1129,10 @@ public class CopyUtils implements Serializable {
 			String[] imType = new String[source.getIms().size()];
 
 			int imSize = 0;
-			if (destination.getAttributes("oxTrustImsValue") != null && destination.getAttributes("oxTrustImsValue").length > 0) {
-				imValue = destination.getAttributes("oxTrustImsValue");
+			if (destination.getAttributes(OX_TRUST_IMS_VALUE) != null && destination.getAttributes(OX_TRUST_IMS_VALUE).length > 0) {
+				imValue = destination.getAttributes(OX_TRUST_IMS_VALUE);
 				imType = destination.getAttributes("oxTrustImsType");
-				imSize = destination.getAttributes("oxTrustImsValue").length;
+				imSize = destination.getAttributes(OX_TRUST_IMS_VALUE).length;
 			}
 
 			for (ScimPersonIms im : ims) {
@@ -1186,7 +1144,7 @@ public class CopyUtils implements Serializable {
 				}
 				imSize++;
 			}
-			destination.setAttribute("oxTrustImsValue", imValue);
+			destination.setAttribute(OX_TRUST_IMS_VALUE, imValue);
 			destination.setAttribute("oxTrustImsType", imType);
 		}
 
@@ -1198,10 +1156,10 @@ public class CopyUtils implements Serializable {
 			String[] photoValue = new String[source.getPhotos().size()];
 
 			int photoSize = 0;
-			if (destination.getAttributes("oxTrustPhotos") != null && destination.getAttributes("oxTrustPhotos").length > 0) {
-				photoType = destination.getAttributes("oxTrustPhotosType");
-				photoValue = destination.getAttributes("oxTrustPhotos");
-				photoSize = destination.getAttributes("oxTrustPhotosType").length;
+			if (destination.getAttributes(OX_TRUST_PHOTOS) != null && destination.getAttributes(OX_TRUST_PHOTOS).length > 0) {
+				photoType = destination.getAttributes(OX_TRUST_PHOTOS_TYPE);
+				photoValue = destination.getAttributes(OX_TRUST_PHOTOS);
+				photoSize = destination.getAttributes(OX_TRUST_PHOTOS_TYPE).length;
 			}
 
 			for (ScimPersonPhotos photo : photos) {
@@ -1213,27 +1171,27 @@ public class CopyUtils implements Serializable {
 				}
 				photoSize++;
 			}
-			destination.setAttribute("oxTrustPhotosType", photoType);
-			destination.setAttribute("oxTrustPhotos", photoValue);
+			destination.setAttribute(OX_TRUST_PHOTOS_TYPE, photoType);
+			destination.setAttribute(OX_TRUST_PHOTOS, photoValue);
 		}
 
 		if (source.getUserType() != null && source.getUserType().length() > 0) {
-			destination.setAttribute("oxTrustUserType", source.getUserType());
+			destination.setAttribute(OX_TRUST_USER_TYPE, source.getUserType());
 		}
 		if (source.getTitle() != null && source.getTitle().length() > 0) {
-			destination.setAttribute("oxTrustTitle", source.getTitle());
+			destination.setAttribute(OX_TRUST_TITLE, source.getTitle());
 		}
 		if (source.getPreferredLanguage() != null && source.getPreferredLanguage().length() > 0) {
 			destination.setPreferredLanguage(source.getPreferredLanguage());
 		}
 		if (source.getLocale() != null && source.getLocale().length() > 0) {
-			destination.setAttribute("oxTrustLocale", source.getLocale());
+			destination.setAttribute(OX_TRUST_LOCALE, source.getLocale());
 		}
 		if (source.getTimezone() != null && source.getTimezone().length() > 0) {
 			destination.setTimezone(source.getTimezone());
 		}
 		if (source.getActive() != null && source.getActive().length() > 0) {
-			destination.setAttribute("oxTrustActive", source.getActive());
+			destination.setAttribute(OX_TRUST_ACTIVE, source.getActive());
 		}
 		if (source.getPassword() != null && source.getPassword().length() > 0) {
 			destination.setUserPassword(source.getPassword());
@@ -1242,7 +1200,7 @@ public class CopyUtils implements Serializable {
 		// getting user groups
 		log.trace(" setting groups ");
 		if (source.getGroups() != null && source.getGroups().size() > 0) {
-			GroupService groupService = GroupService.instance();
+			IGroupService groupService = GroupService.instance();
 			List<ScimPersonGroupsPatch> listGroups = source.getGroups();
 			List<String> members = new ArrayList<String>();
 			for (ScimPersonGroups group : listGroups) {
@@ -1261,9 +1219,9 @@ public class CopyUtils implements Serializable {
 
 			int rolesSize = 0;
 
-			if (destination.getAttributes("oxTrustRole") != null && destination.getAttributes("oxTrustRole").length > 0) {
-				scimRole = destination.getAttributes("oxTrustRole");
-				rolesSize = destination.getAttributes("oxTrustRole").length;
+			if (destination.getAttributes(OX_TRUST_ROLE) != null && destination.getAttributes(OX_TRUST_ROLE).length > 0) {
+				scimRole = destination.getAttributes(OX_TRUST_ROLE);
+				rolesSize = destination.getAttributes(OX_TRUST_ROLE).length;
 			}
 
 			for (ScimRoles role : roles) {
@@ -1273,7 +1231,7 @@ public class CopyUtils implements Serializable {
 				}
 				rolesSize++;
 			}
-			destination.setAttribute("oxTrustRole", scimRole);
+			destination.setAttribute(OX_TRUST_ROLE, scimRole);
 		}
 
 		// getting entitlements
@@ -1284,10 +1242,10 @@ public class CopyUtils implements Serializable {
 
 			int entsSize = 0;
 
-			if (destination.getAttributes("oxTrustEntitlements") != null
-					&& destination.getAttributes("oxTrustEntitlements").length > 0) {
-				listEnts = destination.getAttributes("oxTrustEntitlements");
-				entsSize = destination.getAttributes("oxTrustEntitlements").length;
+			if (destination.getAttributes(OX_TRUST_ENTITLEMENTS) != null
+					&& destination.getAttributes(OX_TRUST_ENTITLEMENTS).length > 0) {
+				listEnts = destination.getAttributes(OX_TRUST_ENTITLEMENTS);
+				entsSize = destination.getAttributes(OX_TRUST_ENTITLEMENTS).length;
 			}
 
 			for (ScimEntitlements ent : ents) {
@@ -1296,7 +1254,7 @@ public class CopyUtils implements Serializable {
 				}
 				entsSize++;
 			}
-			destination.setAttribute("oxTrustEntitlements", listEnts);
+			destination.setAttribute(OX_TRUST_ENTITLEMENTS, listEnts);
 		}
 
 		// getting x509Certificates
@@ -1305,10 +1263,10 @@ public class CopyUtils implements Serializable {
 			List<Scimx509CertificatesPatch> certs = source.getX509Certificates();
 			String[] listCerts = new String[source.getX509Certificates().size()];
 			int certsSize = 0;
-			if (destination.getAttributes("oxTrustx509Certificate") != null
-					&& destination.getAttributes("oxTrustx509Certificate").length > 0) {
-				listCerts = destination.getAttributes("oxTrustx509Certificate");
-				certsSize = destination.getAttributes("oxTrustx509Certificate").length;
+			if (destination.getAttributes(OX_TRUSTX509_CERTIFICATE) != null
+					&& destination.getAttributes(OX_TRUSTX509_CERTIFICATE).length > 0) {
+				listCerts = destination.getAttributes(OX_TRUSTX509_CERTIFICATE);
+				certsSize = destination.getAttributes(OX_TRUSTX509_CERTIFICATE).length;
 			}
 
 			for (Scimx509Certificates cert : certs) {
@@ -1318,23 +1276,23 @@ public class CopyUtils implements Serializable {
 				certsSize++;
 			}
 
-			destination.setAttribute("oxTrustx509Certificate", listCerts);
+			destination.setAttribute(OX_TRUSTX509_CERTIFICATE, listCerts);
 		}
 
 		// getting meta
 		log.trace(" setting meta ");
 
 		if (source.getMeta().getCreated() != null && source.getMeta().getCreated().length() > 0) {
-			destination.setAttribute("oxTrustMetaCreated", source.getMeta().getCreated());
+			destination.setAttribute(OX_TRUST_META_CREATED, source.getMeta().getCreated());
 		}
 		if (source.getMeta().getLastModified() != null && source.getMeta().getLastModified().length() > 0) {
-			destination.setAttribute("oxTrustMetaLastModified", source.getMeta().getLastModified());
+			destination.setAttribute(OX_TRUST_META_LAST_MODIFIED, source.getMeta().getLastModified());
 		}
 		if (source.getMeta().getVersion() != null && source.getMeta().getVersion().length() > 0) {
-			destination.setAttribute("oxTrustMetaVersion", source.getMeta().getVersion());
+			destination.setAttribute(OX_TRUST_META_VERSION, source.getMeta().getVersion());
 		}
 		if (source.getMeta().getLocation() != null && source.getMeta().getLocation().length() > 0) {
-			destination.setAttribute("oxTrustMetaLocation", source.getMeta().getLocation());
+			destination.setAttribute(OX_TRUST_META_LOCATION, source.getMeta().getLocation());
 		}
 
 		setGluuStatus(source, destination);
@@ -1388,7 +1346,7 @@ public class CopyUtils implements Serializable {
 				destination.setDisplayName(source.getDisplayName());
 			}
 			if (source.getMembers() != null && source.getMembers().size() > 0) {
-				PersonService personService = PersonService.instance();
+				IPersonService personService = PersonService.instance();
 				List<ScimGroupMembers> members = source.getMembers();
 				List<String> listMembers = new ArrayList<String>();
 				for (ScimGroupMembers member : members) {
@@ -1400,7 +1358,7 @@ public class CopyUtils implements Serializable {
 
 		} else {
 			log.trace(" creating a new GroupService instant ");
-			GroupService groupService1 = GroupService.instance();
+			IGroupService groupService1 = GroupService.instance();
 			log.trace(" source.getDisplayName() : ", source.getDisplayName());
 
 			if (groupService1.getGroupByDisplayName(source.getDisplayName()) != null) {
@@ -1416,7 +1374,7 @@ public class CopyUtils implements Serializable {
 			log.trace(" source.getMembers().size() : ", source.getMembers().size());
 
 			if (source.getMembers() != null && source.getMembers().size() > 0) {
-				PersonService personService = PersonService.instance();
+				IPersonService personService = PersonService.instance();
 				List<ScimGroupMembers> members = source.getMembers();
 				List<String> listMembers = new ArrayList<String>();
 				for (ScimGroupMembers member : members) {
@@ -1493,10 +1451,10 @@ public class CopyUtils implements Serializable {
 	}
 
 	private static void setGluuStatus(GluuCustomPerson destination, String active) {
-		if (StringHelper.isNotEmpty(active) && (destination.getAttribute("gluuStatus") == null)) {
+		if (StringHelper.isNotEmpty(active) && (destination.getAttribute(GLUU_STATUS) == null)) {
 			GluuBoolean gluuStatus = GluuBoolean.getByValue(org.xdi.util.StringHelper.toLowerCase(active));
 			if (gluuStatus != null) {
-				destination.setAttribute("gluuStatus", gluuStatus.getValue());
+				destination.setAttribute(GLUU_STATUS, gluuStatus.getValue());
 			}
 		}
 	}

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -104,7 +104,7 @@ public class CopyUtils implements Serializable {
 
 	private static final String OX_TRUST_ACTIVE = "oxTrustActive";
 
-	private static final String OX_TRUST_LOCALE = "oxTrustLocale";
+	private static final String OX_TRUST_LOCALE = "locale";
 
 	private static final String OX_TRUST_TITLE = "oxTrustTitle";
 
@@ -122,7 +122,7 @@ public class CopyUtils implements Serializable {
 
 	private static final String OX_TRUST_PROFILE_URL = "oxTrustProfileURL";
 
-	private static final String OX_TRUST_NICK_NAME = "oxTrustNickName";
+	private static final String OX_TRUST_NICK_NAME = "nickName";
 
 	private static final String OX_TRUST_EXTERNAL_ID = "oxTrustExternalId";
 
@@ -130,7 +130,7 @@ public class CopyUtils implements Serializable {
 
 	private static final String OX_TRUSTHONORIFIC_PREFIX = "oxTrusthonorificPrefix";
 
-	private static final String OX_TRUST_MIDDLE_NAME = "oxTrustMiddleName";
+	private static final String OX_TRUST_MIDDLE_NAME = "middleName";
 
 	/**
      *

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -476,7 +476,7 @@ public class CopyUtils implements Serializable {
 		if (items == null) {
 			log.trace(" removing " + attributeName);
 			destination.removeAttribute("oxTrustEmail");
-		} else if (items.size() > 0) {
+		} else {
 			log.trace(" setting " + attributeName);
 
 			StringWriter listOfItems = new StringWriter();

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils.java
@@ -475,7 +475,7 @@ public class CopyUtils implements Serializable {
 			throws JsonGenerationException, JsonMappingException, IOException {
 		if (items == null) {
 			log.trace(" removing " + attributeName);
-			destination.removeAttribute("oxTrustEmail");
+			destination.removeAttribute(attributeName);
 		} else {
 			log.trace(" setting " + attributeName);
 

--- a/server/src/main/java/org/gluu/oxtrust/util/CopyUtils2.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/CopyUtils2.java
@@ -20,6 +20,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.gluu.oxtrust.ldap.service.AttributeService;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.OrganizationService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
@@ -145,7 +147,7 @@ public class CopyUtils2 implements Serializable {
 			return null;
 		}
 
-		PersonService personService1 = PersonService.instance();
+		IPersonService personService1 = PersonService.instance();
 
 
 		if (destination == null) {
@@ -286,7 +288,7 @@ public class CopyUtils2 implements Serializable {
 			// getting user groups
 			log.trace(" setting groups ");
 			if (source.getGroups() != null && source.getGroups().size() > 0) {
-				GroupService groupService = GroupService.instance();
+				IGroupService groupService = GroupService.instance();
 				List<GroupRef> listGroups = source.getGroups();
 				List<String> members = new ArrayList<String>();
 				for (GroupRef group : listGroups) {
@@ -530,7 +532,7 @@ public class CopyUtils2 implements Serializable {
 				// getting user groups
 				log.trace(" setting groups ");
 				if (source.getGroups() != null && source.getGroups().size() > 0) {
-					GroupService groupService = GroupService.instance();
+					IGroupService groupService = GroupService.instance();
 					List<GroupRef> listGroups = source.getGroups();
 					List<String> members = new ArrayList<String>();
 					for (GroupRef group : listGroups) {
@@ -835,7 +837,7 @@ public class CopyUtils2 implements Serializable {
 		// getting user groups
 		log.trace(" setting  groups ");
 		if (source.getMemberOf() != null) {
-			GroupService groupService = GroupService.instance();
+			IGroupService groupService = GroupService.instance();
 
 			List<String> listOfGroups = source.getMemberOf();
 			List<GroupRef> groupRefList = new ArrayList<GroupRef>();
@@ -1038,7 +1040,7 @@ public class CopyUtils2 implements Serializable {
 		if (destination == null) {
 			destination = new Group();
 		}
-		PersonService personService = PersonService.instance();
+		IPersonService personService = PersonService.instance();
 		destination.setDisplayName(source.getDisplayName());
 		destination.setId(source.getInum());
 		if (source.getMembers() != null) {
@@ -1071,7 +1073,7 @@ public class CopyUtils2 implements Serializable {
 		List<String> listMembers = new ArrayList<String>();
 		// mapMembers.
 
-		PersonService personservice = PersonService.instance();
+		IPersonService personservice = PersonService.instance();
 		for (String dn : listMembers) {
 			GluuCustomPerson gluuPerson = personservice.getPersonByDn(dn);
 			ScimGroupMembers member = new ScimGroupMembers();
@@ -1380,7 +1382,7 @@ public class CopyUtils2 implements Serializable {
 		// getting user groups
 		log.trace(" setting groups ");
 		if (source.getGroups() != null && source.getGroups().size() > 0) {
-			GroupService groupService = GroupService.instance();
+			IGroupService groupService = GroupService.instance();
 			List<ScimPersonGroupsPatch> listGroups = source.getGroups();
 			List<String> members = new ArrayList<String>();
 			for (ScimPersonGroups group : listGroups) {
@@ -1525,7 +1527,7 @@ public class CopyUtils2 implements Serializable {
 				destination.setDisplayName(source.getDisplayName());
 			}
 			if (source.getMembers() != null && source.getMembers().size() > 0) {
-				PersonService personService = PersonService.instance();
+				IPersonService personService = PersonService.instance();
 				Set<MemberRef> members = source.getMembers();
 				List<String> listMembers = new ArrayList<String>();
 				for (MemberRef member : members) {
@@ -1537,7 +1539,7 @@ public class CopyUtils2 implements Serializable {
 
 		} else {
 			log.trace(" creating a new GroupService instant ");
-			GroupService groupService1 = GroupService.instance();
+			IGroupService groupService1 = GroupService.instance();
 			log.trace(" source.getDisplayName() : ", source.getDisplayName());
 
 			if (groupService1.getGroupByDisplayName(source.getDisplayName()) != null) {
@@ -1553,7 +1555,7 @@ public class CopyUtils2 implements Serializable {
 			log.trace(" source.getMembers().size() : ", source.getMembers().size());
 
 			if (source.getMembers() != null && source.getMembers().size() > 0) {
-				PersonService personService = PersonService.instance();
+				IPersonService personService = PersonService.instance();
 				Set<MemberRef> members = source.getMembers();
 				List<String> listMembers = new ArrayList<String>();
 				for (MemberRef member : members) {

--- a/server/src/main/java/org/gluu/oxtrust/util/PeopleUidConverter.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/PeopleUidConverter.java
@@ -11,6 +11,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
 
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 
@@ -23,7 +24,7 @@ public class PeopleUidConverter implements Converter {
         if (value == null) {
             return null;
         }
-        PersonService personService = PersonService.instance();
+        IPersonService personService = PersonService.instance();
         GluuCustomPerson person = personService.getPersonByUid(value);
         return person;
     }

--- a/server/src/main/java/org/gluu/oxtrust/util/Utils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/Utils.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 import org.gluu.oxtrust.config.OxTrustConfiguration;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuGroup;
@@ -34,7 +36,7 @@ public class Utils implements Serializable {
 	 */
 	public static void deleteGroupFromPerson(GluuGroup group, String dn) throws Exception {
 
-		PersonService personService = PersonService.instance();
+		IPersonService personService = PersonService.instance();
 
 		List<String> persons = group.getMembers();
 		for (String onePerson : persons) {
@@ -91,7 +93,7 @@ public class Utils implements Serializable {
 	 */
 	public static void deleteUserFromGroup(GluuCustomPerson person, String dn) throws Exception {
 
-		GroupService groupService = GroupService.instance();
+		IGroupService groupService = GroupService.instance();
 
 		List<String> groups = person.getMemberOf();
 		for (String oneGroup : groups) {
@@ -133,7 +135,7 @@ public class Utils implements Serializable {
 	 * @throws Exception
 	 */
 	public static void personMemebersAdder(GluuGroup gluuGroup, String dn) throws Exception {
-		PersonService personService = PersonService.instance();
+		IPersonService personService = PersonService.instance();
 
 		List<String> members = gluuGroup.getMembers();
 
@@ -180,7 +182,7 @@ public class Utils implements Serializable {
 	 */
 	public static void groupMemebersAdder(GluuCustomPerson gluuPerson, String dn) throws Exception {
 
-		GroupService groupService = GroupService.instance();
+		IGroupService groupService = GroupService.instance();
 
 		List<String> groups = gluuPerson.getMemberOf();
 

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/BulkWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/BulkWebService.java
@@ -30,6 +30,8 @@ import org.apache.log4j.Logger;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuGroup;
@@ -58,10 +60,10 @@ public class BulkWebService extends BaseScimWebService {
 	private static final Logger log = Logger.getLogger(BulkWebService.class);
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@POST
 	@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/ClientAssociationWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/ClientAssociationWebService.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.gluu.oxtrust.ldap.service.ClientService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.OxAuthClient;
@@ -45,7 +46,7 @@ public class ClientAssociationWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private ClientService clientService;

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/GroupWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/GroupWebService.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
 import org.gluu.oxtrust.model.GluuGroup;
 import org.gluu.oxtrust.model.GluuGroupList;
 import org.gluu.oxtrust.model.scim.ScimGroup;
@@ -47,7 +48,7 @@ public class GroupWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@GET
 	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/OxChooserWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/OxChooserWebService.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.codec.binary.Base64;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.ldap.service.SecurityService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
@@ -68,7 +69,7 @@ public class OxChooserWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private SecurityService securityService;

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/UserWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim/UserWebService.java
@@ -35,6 +35,7 @@ import org.codehaus.jackson.map.JsonMappingException;
 import org.dom4j.Document;
 import org.dom4j.io.DOMReader;
 import org.dom4j.io.DocumentSource;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuCustomPersonList;
@@ -65,7 +66,7 @@ public class UserWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private UmaAuthenticationService umaAuthenticationService;

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/BulkWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/BulkWebService.java
@@ -28,10 +28,13 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.Authorization;
+
 import org.apache.log4j.Logger;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.GluuGroup;
@@ -59,10 +62,10 @@ public class BulkWebService extends BaseScimWebService {
 	private static final Logger log = Logger.getLogger(BulkWebService.class);
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@POST
 	@Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/GroupWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/GroupWebService.java
@@ -27,7 +27,9 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.Authorization;
+
 import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
 import org.gluu.oxtrust.model.GluuGroup;
 import org.gluu.oxtrust.model.scim2.Group;
 import org.gluu.oxtrust.model.scim2.ListResponse;
@@ -56,7 +58,7 @@ public class GroupWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private GroupService groupService;
+	private IGroupService groupService;
 
 	@GET
 	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })

--- a/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/UserWebService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ws/rs/scim2/UserWebService.java
@@ -26,8 +26,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.wordnik.swagger.annotations.*;
+
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.ldap.service.PersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.model.scim.ScimPerson;
@@ -63,7 +65,7 @@ public class UserWebService extends BaseScimWebService {
 	private Log log;
 
 	@In
-	private PersonService personService;
+	private IPersonService personService;
 
 	@In
 	private UmaAuthenticationService umaAuthenticationService;

--- a/server/src/test/java/org/gluu/oxtrust/service/test/GroupServiceTest.java
+++ b/server/src/test/java/org/gluu/oxtrust/service/test/GroupServiceTest.java
@@ -7,7 +7,7 @@
 package org.gluu.oxtrust.service.test;
 
 import org.gluu.oxtrust.action.test.ConfigurableTest;
-import org.gluu.oxtrust.ldap.service.GroupService;
+import org.gluu.oxtrust.ldap.service.IGroupService;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.mock.JUnitSeamTest;
 import org.junit.Assert;
@@ -27,7 +27,7 @@ public class GroupServiceTest extends ConfigurableTest {
 		new JUnitSeamTest.FacesRequest() {
             @Override
             public void invokeApplication() throws Exception {
-                GroupService groupService = (GroupService) getInstance("groupService");
+                IGroupService groupService = (IGroupService) getInstance("groupService");
 
                 String groupDn = testData.getString("test.group.dn");
                 String ownerDn = testData.getString("test.group.dn.ownerDn");

--- a/server/src/test/java/org/gluu/oxtrust/service/test/PersonServiceTest.java
+++ b/server/src/test/java/org/gluu/oxtrust/service/test/PersonServiceTest.java
@@ -9,7 +9,7 @@ package org.gluu.oxtrust.service.test;
 import java.util.List;
 
 import org.gluu.oxtrust.action.test.AbstractAuthorizationTest;
-import org.gluu.oxtrust.ldap.service.PersonService;
+import org.gluu.oxtrust.ldap.service.IPersonService;
 import org.gluu.oxtrust.model.GluuCustomPerson;
 import org.gluu.oxtrust.util.OxTrustConstants;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,7 +36,7 @@ public class PersonServiceTest extends AbstractAuthorizationTest {
 
 			@Override
 			protected void invokeApplication() throws Exception {
-				PersonService personService = (PersonService) getInstance("personService");
+				IPersonService personService = (IPersonService) getInstance("personService");
 
 				String pattern = testData.getString("person.search.pattern");
 				List<GluuCustomPerson> persons = personService.searchPersons(pattern, OxTrustConstants.searchPersonsSizeLimit);
@@ -52,7 +52,7 @@ public class PersonServiceTest extends AbstractAuthorizationTest {
 		new JUnitSeamTest.FacesRequest() {
 			@Override
 			protected void invokeApplication() throws Exception {
-				PersonService personService = (PersonService) getInstance("personService");
+				IPersonService personService = (IPersonService) getInstance("personService");
 
 				String personUid = testData.getString("person.uid");
 				GluuCustomPerson person = personService.getPersonByUid(personUid);

--- a/server/src/test/java/org/gluu/oxtrust/util/CopyUtilsTestCreate.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/CopyUtilsTestCreate.java
@@ -1,0 +1,1305 @@
+package org.gluu.oxtrust.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gluu.oxtrust.model.GluuCustomAttribute;
+import org.gluu.oxtrust.model.GluuCustomPerson;
+import org.gluu.oxtrust.model.scim.PersonMeta;
+import org.gluu.oxtrust.model.scim.ScimCustomAttributes;
+import org.gluu.oxtrust.model.scim.ScimEntitlements;
+import org.gluu.oxtrust.model.scim.ScimName;
+import org.gluu.oxtrust.model.scim.ScimPerson;
+import org.gluu.oxtrust.model.scim.ScimPersonAddresses;
+import org.gluu.oxtrust.model.scim.ScimPersonEmails;
+import org.gluu.oxtrust.model.scim.ScimPersonGroups;
+import org.gluu.oxtrust.model.scim.ScimPersonIms;
+import org.gluu.oxtrust.model.scim.ScimPersonPhones;
+import org.gluu.oxtrust.model.scim.ScimPersonPhotos;
+import org.gluu.oxtrust.model.scim.ScimRoles;
+import org.gluu.oxtrust.model.scim.Scimx509Certificates;
+import org.jboss.seam.mock.SeamTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class CopyUtilsTestCreate extends SeamTest {
+	private static final String GLUU_STATUS = "gluuStatus";
+
+	private static final String OX_TRUST_PHOTOS_TYPE = "oxTrustPhotosType";
+
+	private static final String OX_TRUST_PHONE_TYPE = "oxTrustPhoneType";
+
+	private static final String OX_TRUST_ADDRESS_PRIMARY = "oxTrustAddressPrimary";
+
+	private static final String OX_TRUST_ADDRESS_TYPE = "oxTrustAddressType";
+
+	private static final String OX_TRUST_COUNTRY = "oxTrustCountry";
+
+	private static final String OX_TRUST_POSTAL_CODE = "oxTrustPostalCode";
+
+	private static final String OX_TRUST_REGION = "oxTrustRegion";
+
+	private static final String OX_TRUST_LOCALITY = "oxTrustLocality";
+
+	private static final String OX_TRUST_ADDRESS_FORMATTED = "oxTrustAddressFormatted";
+
+	private static final String OX_TRUST_STREET = "oxTrustStreet";
+
+	private static final String OX_TRUST_EMAIL_PRIMARY = "oxTrustEmailPrimary";
+
+	private static final String OX_TRUST_EMAIL_TYPE = "oxTrustEmailType";
+
+	private static final String OX_TRUST_META_LOCATION = "oxTrustMetaLocation";
+
+	private static final String OX_TRUST_META_VERSION = "oxTrustMetaVersion";
+
+	private static final String OX_TRUST_META_LAST_MODIFIED = "oxTrustMetaLastModified";
+
+	private static final String OX_TRUST_META_CREATED = "oxTrustMetaCreated";
+
+	private static final String OX_TRUSTX509_CERTIFICATE = "oxTrustx509Certificate";
+
+	private static final String OX_TRUST_ENTITLEMENTS = "oxTrustEntitlements";
+
+	private static final String OX_TRUST_ROLE = "oxTrustRole";
+
+	private static final String OX_TRUST_ACTIVE = "oxTrustActive";
+
+	private static final String OX_TRUST_LOCALE = "oxTrustLocale";
+
+	private static final String OX_TRUST_TITLE = "oxTrustTitle";
+
+	private static final String OX_TRUST_USER_TYPE = "oxTrustUserType";
+
+	private static final String OX_TRUST_PHOTOS = "oxTrustPhotos";
+
+	private static final String OX_TRUST_IMS_VALUE = "oxTrustImsValue";
+
+	private static final String OX_TRUST_PHONE_VALUE = "oxTrustPhoneValue";
+
+	private static final String OX_TRUST_ADDRESSES = "oxTrustAddresses";
+
+	private static final String OX_TRUST_EMAIL = "oxTrustEmail";
+
+	private static final String OX_TRUST_PROFILE_URL = "oxTrustProfileURL";
+
+	private static final String OX_TRUST_NICK_NAME = "oxTrustNickName";
+
+	private static final String OX_TRUST_EXTERNAL_ID = "oxTrustExternalId";
+
+	private static final String OX_TRUSTHONORIFIC_SUFFIX = "oxTrusthonorificSuffix";
+
+	private static final String OX_TRUSTHONORIFIC_PREFIX = "oxTrusthonorificPrefix";
+
+	private static final String OX_TRUST_MIDDLE_NAME = "oxTrustMiddleName";
+	@Before
+	public void startSeamInstance() throws Exception {
+		startSeam();
+		begin();
+	}
+
+	@After
+	public void stopSeamInstance() throws Exception {
+		end();
+		stopSeam();
+	}
+
+	@Test
+	public void testCopyScim1EmptyCreate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNull(copy);
+			}
+		}.run();
+	}
+
+	@Test
+	public void testCopyScim1FilledCreate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(1,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				
+				assertEquals("true",copy.getAttribute(GLUU_STATUS));				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("true",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+				assertNull(copy.getAssociatedClient());
+				assertNull(copy.getBaseDn());
+				assertNull(copy.getCommonName());
+				List<GluuCustomAttribute> customAttributes2 = copy.getCustomAttributes();
+				assertNotNull(customAttributes2);
+				assertEquals(32,customAttributes2.size());
+				
+				assertEquals("displayName",copy.getDisplayName());
+				assertNull(copy.getDn());
+				assertEquals("givenName",copy.getGivenName());
+				assertNull(copy.getGluuAllowPublication());
+				GluuCustomAttribute gluuCustomAttribute = copy.getGluuCustomAttribute("custom_name");
+				assertNotNull(gluuCustomAttribute);
+				assertEquals("custom_name", gluuCustomAttribute.getName());				
+				assertEquals("value", gluuCustomAttribute.getValue());
+				assertNull(gluuCustomAttribute.getDate());
+				assertEquals("value",gluuCustomAttribute.getDisplayValue());
+				assertNull(gluuCustomAttribute.getMetadata());
+				assertEquals("value",gluuCustomAttribute.getValues()[0]);
+				assertNull(copy.getGluuOptOuts());
+				assertNull(copy.getIname());
+				assertNull(copy.getMail());
+				assertEquals("Mocked DN",copy.getMemberOf().get(0));
+				assertNull(copy.getNetworkPoken());
+				assertNull(copy.getOxCreationTimestamp());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertNull(copy.getSLAManager());
+				assertNull(copy.getSourceServerName());
+				assertNull(copy.getStatus());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("userName",copy.getUid());
+				assertEquals("password",copy.getUserPassword());
+			}
+		}.run();
+	}
+	
+
+	@Test
+	public void testCopyScim1FilledCreateExisting() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				
+				
+				destination.setAllowPublication(true);
+				List<String> associatedClientDNs = new ArrayList<String>();
+				associatedClientDNs.add("a");
+				associatedClientDNs.add("b");
+				associatedClientDNs.add("c");
+				destination.setAssociatedClient(associatedClientDNs );
+				destination.setBaseDn("dn");
+				destination.setAttribute(OX_TRUST_NICK_NAME, "original nickname");
+				destination.setAttribute(OX_TRUST_PROFILE_URL, "original url");
+				destination.setCommonName("CN");
+				destination.setGivenName("original givenname");
+				destination.setPreferredLanguage("Nederlands");
+
+				
+				destination.setAttribute(OX_TRUST_ENTITLEMENTS, "[{\"value\":\"original entitlement_value\"}]");
+				
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				
+				ScimCustomAttributes customattribute2 = new ScimCustomAttributes();
+				customattribute2.setName("custom_name2");
+				List<String> values2 = new ArrayList<String>();
+				String value2 = "value";
+				values2.add(value2);
+				customattribute2.setValues(values2);
+				customAttributes.add(customattribute2);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl(null);
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("existing");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNull(copy);
+			}
+		}.run();
+	}
+
+	@Test
+	public void testCopyScim1FilledMultipleAttributesCreate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				values.add("value1");
+				values.add("value3");
+				values.add("value2");
+				values.add("value4");
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group1 = new ScimPersonGroups();
+				group1.setDisplay("group_display");
+				group1.setValue("group_value");
+				ScimPersonGroups group2 = new ScimPersonGroups();
+				group2.setDisplay("group_display1");
+				group2.setValue("group_value1");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group1);
+				groups.add(group2);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(2,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				assertEquals("Mocked DN1", copy.getMemberOf().get(1));
+				
+				assertEquals("true",copy.getAttribute(GLUU_STATUS));
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("true",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1FilledNullCustomAttributesCreate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("active");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+					
+				source.setCustomAttributes(null);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group1 = new ScimPersonGroups();
+				group1.setDisplay("group_display");
+				group1.setValue("group_value");
+				ScimPersonGroups group2 = new ScimPersonGroups();
+				group2.setDisplay("group_display1");
+				group2.setValue("group_value1");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group1);
+				groups.add(group2);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(2,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				assertEquals("Mocked DN1", copy.getMemberOf().get(1));
+				
+				assertNull(copy.getAttribute(GLUU_STATUS));
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("active",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1MixedCreate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("false");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setLocality(null);	
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();	
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("");
+				meta.setLastModified("");
+				meta.setLocation("");
+				meta.setVersion("");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				source.setX509Certificates(null);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertNull(copy.getPreferredLanguage());
+				assertNull(copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(0,copy.getMemberOf().size());
+				
+				assertEquals("false",copy.getAttribute(GLUU_STATUS));
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertNull(copy.getAttribute(OX_TRUST_META_VERSION));
+				assertNull(copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertNull(copy.getAttribute(OX_TRUST_META_CREATED));
+				assertNull(copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("false",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":null,\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1createNullSource() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = null;
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNull(copy);
+			}
+
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1CreateNullDestination() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = null;
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNotNull(copy);
+			}
+
+		}.run();
+	}
+	@Test
+	public void testCopyScim1CreateException() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = null;
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("exception");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, false);
+				assertNull(copy);
+			}
+
+		}.run();
+	}
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/CopyUtilsTestUpdate.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/CopyUtilsTestUpdate.java
@@ -1,0 +1,1398 @@
+package org.gluu.oxtrust.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gluu.oxtrust.model.GluuCustomAttribute;
+import org.gluu.oxtrust.model.GluuCustomPerson;
+import org.gluu.oxtrust.model.scim.PersonMeta;
+import org.gluu.oxtrust.model.scim.ScimCustomAttributes;
+import org.gluu.oxtrust.model.scim.ScimEntitlements;
+import org.gluu.oxtrust.model.scim.ScimName;
+import org.gluu.oxtrust.model.scim.ScimPerson;
+import org.gluu.oxtrust.model.scim.ScimPersonAddresses;
+import org.gluu.oxtrust.model.scim.ScimPersonEmails;
+import org.gluu.oxtrust.model.scim.ScimPersonGroups;
+import org.gluu.oxtrust.model.scim.ScimPersonIms;
+import org.gluu.oxtrust.model.scim.ScimPersonPhones;
+import org.gluu.oxtrust.model.scim.ScimPersonPhotos;
+import org.gluu.oxtrust.model.scim.ScimRoles;
+import org.gluu.oxtrust.model.scim.Scimx509Certificates;
+import org.jboss.seam.mock.SeamTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class CopyUtilsTestUpdate extends SeamTest {
+	private static final String GLUU_STATUS = "gluuStatus";
+
+	private static final String OX_TRUST_PHOTOS_TYPE = "oxTrustPhotosType";
+
+	private static final String OX_TRUST_PHONE_TYPE = "oxTrustPhoneType";
+
+	private static final String OX_TRUST_ADDRESS_PRIMARY = "oxTrustAddressPrimary";
+
+	private static final String OX_TRUST_ADDRESS_TYPE = "oxTrustAddressType";
+
+	private static final String OX_TRUST_COUNTRY = "oxTrustCountry";
+
+	private static final String OX_TRUST_POSTAL_CODE = "oxTrustPostalCode";
+
+	private static final String OX_TRUST_REGION = "oxTrustRegion";
+
+	private static final String OX_TRUST_LOCALITY = "oxTrustLocality";
+
+	private static final String OX_TRUST_ADDRESS_FORMATTED = "oxTrustAddressFormatted";
+
+	private static final String OX_TRUST_STREET = "oxTrustStreet";
+
+	private static final String OX_TRUST_EMAIL_PRIMARY = "oxTrustEmailPrimary";
+
+	private static final String OX_TRUST_EMAIL_TYPE = "oxTrustEmailType";
+
+	private static final String OX_TRUST_META_LOCATION = "oxTrustMetaLocation";
+
+	private static final String OX_TRUST_META_VERSION = "oxTrustMetaVersion";
+
+	private static final String OX_TRUST_META_LAST_MODIFIED = "oxTrustMetaLastModified";
+
+	private static final String OX_TRUST_META_CREATED = "oxTrustMetaCreated";
+
+	private static final String OX_TRUSTX509_CERTIFICATE = "oxTrustx509Certificate";
+
+	private static final String OX_TRUST_ENTITLEMENTS = "oxTrustEntitlements";
+
+	private static final String OX_TRUST_ROLE = "oxTrustRole";
+
+	private static final String OX_TRUST_ACTIVE = "oxTrustActive";
+
+	private static final String OX_TRUST_LOCALE = "oxTrustLocale";
+
+	private static final String OX_TRUST_TITLE = "oxTrustTitle";
+
+	private static final String OX_TRUST_USER_TYPE = "oxTrustUserType";
+
+	private static final String OX_TRUST_PHOTOS = "oxTrustPhotos";
+
+	private static final String OX_TRUST_IMS_VALUE = "oxTrustImsValue";
+
+	private static final String OX_TRUST_PHONE_VALUE = "oxTrustPhoneValue";
+
+	private static final String OX_TRUST_ADDRESSES = "oxTrustAddresses";
+
+	private static final String OX_TRUST_EMAIL = "oxTrustEmail";
+
+	private static final String OX_TRUST_PROFILE_URL = "oxTrustProfileURL";
+
+	private static final String OX_TRUST_NICK_NAME = "oxTrustNickName";
+
+	private static final String OX_TRUST_EXTERNAL_ID = "oxTrustExternalId";
+
+	private static final String OX_TRUSTHONORIFIC_SUFFIX = "oxTrusthonorificSuffix";
+
+	private static final String OX_TRUSTHONORIFIC_PREFIX = "oxTrusthonorificPrefix";
+
+	private static final String OX_TRUST_MIDDLE_NAME = "oxTrustMiddleName";
+	@Before
+	public void startSeamInstance() throws Exception {
+		startSeam();
+		begin();
+	}
+
+	@After
+	public void stopSeamInstance() throws Exception {
+		end();
+		stopSeam();
+	}
+
+	@Test
+	public void testCopyScim1EmptyUpdate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertNull(copy.getUid());
+				assertNull(copy.getGivenName());
+				assertNull(copy.getSurname());
+				assertNull(copy.getDisplayName());
+				assertNull(copy.getPreferredLanguage());
+				assertNull(copy.getTimezone());
+				assertNull(copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(0,copy.getMemberOf().size());
+				
+				assertNull(copy.getAttribute(GLUU_STATUS));
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertNull(copy.getAttribute(OX_TRUST_META_VERSION));
+				assertNull(copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertNull(copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_ROLE));
+				assertNull(copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+
+	@Test
+	public void testCopyScim1FilledUpdate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("active");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(1,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				
+				assertNull(copy.getAttribute(GLUU_STATUS));				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("active",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+				assertNull(copy.getAssociatedClient());
+				assertNull(copy.getBaseDn());
+				assertNull(copy.getCommonName());
+				List<GluuCustomAttribute> customAttributes2 = copy.getCustomAttributes();
+				assertNotNull(customAttributes2);
+				assertEquals(31,customAttributes2.size());
+				
+				assertEquals("displayName",copy.getDisplayName());
+				assertNull(copy.getDn());
+				assertEquals("givenName",copy.getGivenName());
+				assertNull(copy.getGluuAllowPublication());
+				GluuCustomAttribute gluuCustomAttribute = copy.getGluuCustomAttribute("custom_name");
+				assertNotNull(gluuCustomAttribute);
+				assertEquals("custom_name", gluuCustomAttribute.getName());				
+				assertEquals("value", gluuCustomAttribute.getValue());
+				assertNull(gluuCustomAttribute.getDate());
+				assertEquals("value",gluuCustomAttribute.getDisplayValue());
+				assertNull(gluuCustomAttribute.getMetadata());
+				assertEquals("value",gluuCustomAttribute.getValues()[0]);
+				assertNull(copy.getGluuOptOuts());
+				assertNull(copy.getIname());
+				assertNull(copy.getMail());
+				assertEquals("Mocked DN",copy.getMemberOf().get(0));
+				assertNull(copy.getNetworkPoken());
+				assertNull(copy.getOxCreationTimestamp());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertNull(copy.getSLAManager());
+				assertNull(copy.getSourceServerName());
+				assertNull(copy.getStatus());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("userName",copy.getUid());
+				assertEquals("password",copy.getUserPassword());
+			}
+		}.run();
+	}
+	
+
+	@Test
+	public void testCopyScim1FilledUpdateExisting() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				
+				
+				destination.setAllowPublication(true);
+				List<String> associatedClientDNs = new ArrayList<String>();
+				associatedClientDNs.add("a");
+				associatedClientDNs.add("b");
+				associatedClientDNs.add("c");
+				destination.setAssociatedClient(associatedClientDNs );
+				destination.setBaseDn("dn");
+				destination.setAttribute(OX_TRUST_NICK_NAME, "original nickname");
+				destination.setAttribute(OX_TRUST_PROFILE_URL, "original url");
+				destination.setCommonName("CN");
+				destination.setGivenName("original givenname");
+				destination.setPreferredLanguage("Nederlands");
+
+				
+				destination.setAttribute(OX_TRUST_ENTITLEMENTS, "[{\"value\":\"original entitlement_value\"}]");
+				
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				String value = "value";
+				values.add(value);
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				
+				ScimCustomAttributes customattribute2 = new ScimCustomAttributes();
+				customattribute2.setName("custom_name2");
+				List<String> values2 = new ArrayList<String>();
+				String value2 = "value";
+				values2.add(value2);
+				customattribute2.setValues(values2);
+				customAttributes.add(customattribute2);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group = new ScimPersonGroups();
+				group.setDisplay("group_display");
+				group.setValue("group_value");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl(null);
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(1,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				
+				assertEquals("true",copy.getAttribute(GLUU_STATUS));			
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("true",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertNull(copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+				assertEquals(3,copy.getAssociatedClient().size());
+				assertEquals("dn",copy.getBaseDn());
+				assertEquals("CN",copy.getCommonName());
+				List<GluuCustomAttribute> customAttributes2 = copy.getCustomAttributes();
+				assertNotNull(customAttributes2);
+				assertEquals(33,customAttributes2.size());
+				
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("dn",copy.getDn());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("true",copy.getGluuAllowPublication());
+				GluuCustomAttribute gluuCustomAttribute = copy.getGluuCustomAttribute("custom_name");
+				assertNotNull(gluuCustomAttribute);
+				assertEquals("custom_name", gluuCustomAttribute.getName());				
+				assertEquals("value", gluuCustomAttribute.getValue());
+				assertNull(gluuCustomAttribute.getDate());
+				assertEquals("value",gluuCustomAttribute.getDisplayValue());
+				assertNull(gluuCustomAttribute.getMetadata());
+				assertEquals("value",gluuCustomAttribute.getValues()[0]);
+				assertNull(copy.getGluuOptOuts());
+				assertNull(copy.getIname());
+				assertNull(copy.getMail());
+				assertEquals("Mocked DN",copy.getMemberOf().get(0));
+				assertNull(copy.getNetworkPoken());
+				assertNull(copy.getOxCreationTimestamp());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertNull(copy.getSLAManager());
+				assertNull(copy.getSourceServerName());
+				assertNull(copy.getStatus());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("userName",copy.getUid());
+				assertEquals("password",copy.getUserPassword());
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1EmptyCustomAttributeUpdateExisting() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				
+				
+				destination.setAllowPublication(true);
+				List<String> associatedClientDNs = new ArrayList<String>();
+				associatedClientDNs.add("a");
+				associatedClientDNs.add("b");
+				associatedClientDNs.add("c");
+				destination.setAssociatedClient(associatedClientDNs );
+				destination.setBaseDn("dn");
+				destination.setAttribute(OX_TRUST_NICK_NAME, "original nickname");
+				destination.setAttribute(OX_TRUST_PROFILE_URL, "original url");
+				destination.setCommonName("CN");
+				destination.setGivenName("original givenname");
+				destination.setPreferredLanguage("Nederlands");
+
+				
+				destination.setAttribute(OX_TRUST_ENTITLEMENTS, "[{\"value\":\"original entitlement_value\"}]");
+				
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName(null);
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl(null);
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertNull(copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(0,copy.getMemberOf().size());
+				
+				assertEquals("true",copy.getAttribute(GLUU_STATUS));			
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("true",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertNull(copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+				assertEquals(3,copy.getAssociatedClient().size());
+				assertEquals("dn",copy.getBaseDn());
+				assertEquals("CN",copy.getCommonName());
+				List<GluuCustomAttribute> customAttributes2 = copy.getCustomAttributes();
+				assertNotNull(customAttributes2);
+				assertEquals(30,customAttributes2.size());
+				
+				assertNull(copy.getDisplayName());
+				assertEquals("dn",copy.getDn());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("true",copy.getGluuAllowPublication());
+				GluuCustomAttribute gluuCustomAttribute = copy.getGluuCustomAttribute("custom_name");
+				assertNotNull(gluuCustomAttribute);
+				assertEquals("custom_name", gluuCustomAttribute.getName());				
+				assertNull(gluuCustomAttribute.getValue());
+				assertNull(gluuCustomAttribute.getDate());
+				assertEquals("",gluuCustomAttribute.getDisplayValue());
+				assertNull(gluuCustomAttribute.getMetadata());
+				assertEquals(0,gluuCustomAttribute.getValues().length);
+				assertNull(copy.getGluuOptOuts());
+				assertNull(copy.getIname());
+				assertNull(copy.getMail());
+				assertEquals(0,copy.getMemberOf().size());
+				assertNull(copy.getNetworkPoken());
+				assertNull(copy.getOxCreationTimestamp());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertNull(copy.getSLAManager());
+				assertNull(copy.getSourceServerName());
+				assertNull(copy.getStatus());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("userName",copy.getUid());
+				assertEquals("password",copy.getUserPassword());
+			}
+		}.run();
+	}
+
+	@Test
+	public void testCopyScim1FilledMultipleAttributesUpdate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("true");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();
+				ScimCustomAttributes customattribute = new ScimCustomAttributes();
+				customattribute.setName("custom_name");
+				List<String> values = new ArrayList<String>();
+				values.add("value1");
+				values.add("value3");
+				values.add("value2");
+				values.add("value4");
+				customattribute.setValues(values);
+				customAttributes.add(customattribute);
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group1 = new ScimPersonGroups();
+				group1.setDisplay("group_display");
+				group1.setValue("group_value");
+				ScimPersonGroups group2 = new ScimPersonGroups();
+				group2.setDisplay("group_display1");
+				group2.setValue("group_value1");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group1);
+				groups.add(group2);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(2,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				assertEquals("Mocked DN1", copy.getMemberOf().get(1));
+				
+				assertEquals("true",copy.getAttribute(GLUU_STATUS));
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("true",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1FilledNullCustomAttributesUpdate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("active");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("formatted");
+				address.setLocality("locality");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+					
+				source.setCustomAttributes(null);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				ScimPersonGroups group1 = new ScimPersonGroups();
+				group1.setDisplay("group_display");
+				group1.setValue("group_value");
+				ScimPersonGroups group2 = new ScimPersonGroups();
+				group2.setDisplay("group_display1");
+				group2.setValue("group_value1");
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				groups.add(group1);
+				groups.add(group2);
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("created");
+				meta.setLastModified("lastModified");
+				meta.setLocation("location");
+				meta.setVersion("version");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("preferredLanguage");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("timezone");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				Scimx509Certificates cert = new Scimx509Certificates();
+				cert.setValue("cert_value");
+				List<Scimx509Certificates> x509Certificates = new ArrayList<Scimx509Certificates>();
+				x509Certificates.add(cert);
+				source.setX509Certificates(x509Certificates);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertEquals("preferredLanguage",copy.getPreferredLanguage());
+				assertEquals("timezone",copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(2,copy.getMemberOf().size());
+				assertEquals("Mocked DN", copy.getMemberOf().get(0));
+				assertEquals("Mocked DN1", copy.getMemberOf().get(1));
+				
+				assertNull(copy.getAttribute(GLUU_STATUS));
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertEquals("location",copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertEquals("version",copy.getAttribute(OX_TRUST_META_VERSION));
+				assertEquals("lastModified",copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertEquals("created",copy.getAttribute(OX_TRUST_META_CREATED));
+				assertEquals("[{\"value\":\"cert_value\"}]",copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("active",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":\"locality\",\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"formatted\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1MixedUpdate() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = new ScimPerson();
+				
+				source.setActive("false");
+				
+				ScimPersonAddresses address  = new ScimPersonAddresses();
+				address.setCountry("country");
+				address.setFormatted("");
+				address.setPostalCode("postalCode");
+				address.setPrimary("address_primary");
+				address.setRegion("region");
+				address.setLocality(null);	
+				address.setStreetAddress("streetAddress");
+				address.setType("address_type");
+				List<ScimPersonAddresses> addresses = new ArrayList<ScimPersonAddresses>();
+				addresses.add(address);
+				
+				source.setAddresses(addresses );
+				
+				
+				List<ScimCustomAttributes> customAttributes = new ArrayList<ScimCustomAttributes>();	
+				source.setCustomAttributes(customAttributes);
+				
+				source.setDisplayName("displayName");
+				
+				ScimPersonEmails email = new ScimPersonEmails();
+				email.setPrimary("email_primary");
+				email.setType("email_type");
+				email.setValue("email_value");
+				List<ScimPersonEmails> emails = new ArrayList<ScimPersonEmails>();
+				emails.add(email);
+				source.setEmails(emails);
+
+				ScimEntitlements entitlement = new ScimEntitlements();
+				entitlement.setValue("entitlement_value");
+				List<ScimEntitlements> entitlements = new ArrayList<ScimEntitlements>();
+				entitlements.add(entitlement);
+				source.setEntitlements(entitlements);
+				
+				source.setExternalId("externalId");
+
+				List<ScimPersonGroups> groups = new ArrayList<ScimPersonGroups>();
+				source.setGroups(groups);
+				
+				source.setId("id");
+				
+				ScimPersonIms personims = new ScimPersonIms();
+				personims.setType("ims_type");
+				personims.setValue("ims_value");
+				List<ScimPersonIms> ims = new ArrayList<ScimPersonIms>();
+				ims.add(personims);
+				source.setIms(ims);
+				
+				source.setLocale("locale");
+				
+				PersonMeta meta = new PersonMeta();
+				meta.setCreated("");
+				meta.setLastModified("");
+				meta.setLocation("");
+				meta.setVersion("");
+				source.setMeta(meta);
+				
+				ScimName name = new ScimName();
+				name.setFamilyName("familyName");
+				name.setGivenName("givenName");
+				name.setHonorificPrefix("honorificPrefix");
+				name.setHonorificSuffix("honorificSuffix");
+				name.setMiddleName("middleName");
+				source.setName(name);
+				
+				source.setNickName("nickName");
+				source.setPassword("password");
+				
+				ScimPersonPhones phonenumber = new ScimPersonPhones();
+				phonenumber.setType("phone_type");
+				phonenumber.setValue("phone_value");
+				List<ScimPersonPhones> phoneNumbers = new ArrayList<ScimPersonPhones>();
+				phoneNumbers.add(phonenumber);
+				source.setPhoneNumbers(phoneNumbers);
+				
+				ScimPersonPhotos photo= new ScimPersonPhotos();
+				photo.setType("photo_type");
+				photo.setValue("photo_value");
+				List<ScimPersonPhotos> photos = new ArrayList<ScimPersonPhotos>();
+				photos.add(photo);
+				source.setPhotos(photos);
+
+				source.setPreferredLanguage("");
+				source.setProfileUrl("profileUrl");
+				
+				ScimRoles role = new ScimRoles();
+				role.setValue("role_value");
+				List<ScimRoles> roles = new ArrayList<ScimRoles>();
+				roles.add(role);
+				source.setRoles(roles);
+				
+				List<String> schemas = new ArrayList<String>();
+				schemas.add("shema");
+				source.setSchemas(schemas);
+				
+				source.setTimezone("");
+				source.setTitle("title");
+				source.setUserName("userName");
+				source.setUserType("userType");
+				
+				source.setX509Certificates(null);
+				
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+				assertEquals("userName",copy.getUid());
+				assertEquals("givenName",copy.getGivenName());
+				assertEquals("familyName",copy.getSurname());
+				assertEquals("displayName",copy.getDisplayName());
+				assertNull(copy.getPreferredLanguage());
+				assertNull(copy.getTimezone());
+				assertEquals("password",copy.getUserPassword());
+				assertNotNull(copy.getMemberOf());
+				assertEquals(0,copy.getMemberOf().size());
+				
+				assertEquals("false",copy.getAttribute(GLUU_STATUS));
+				
+				assertNull(copy.getAttribute(OX_TRUST_PHOTOS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_PHONE_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_COUNTRY));
+				assertNull(copy.getAttribute(OX_TRUST_POSTAL_CODE));
+				assertNull(copy.getAttribute(OX_TRUST_REGION));
+				assertNull(copy.getAttribute(OX_TRUST_LOCALITY));
+				assertNull(copy.getAttribute(OX_TRUST_ADDRESS_FORMATTED));
+				assertNull(copy.getAttribute(OX_TRUST_STREET));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_PRIMARY));
+				assertNull(copy.getAttribute(OX_TRUST_EMAIL_TYPE));
+				assertNull(copy.getAttribute(OX_TRUST_META_LOCATION));
+				assertNull(copy.getAttribute(OX_TRUST_META_VERSION));
+				assertNull(copy.getAttribute(OX_TRUST_META_LAST_MODIFIED));
+				assertNull(copy.getAttribute(OX_TRUST_META_CREATED));
+				assertNull(copy.getAttribute(OX_TRUSTX509_CERTIFICATE));
+				assertEquals("[{\"value\":\"entitlement_value\"}]",copy.getAttribute(OX_TRUST_ENTITLEMENTS));
+				assertEquals("[{\"value\":\"role_value\"}]",copy.getAttribute(OX_TRUST_ROLE));
+				assertEquals("false",copy.getAttribute(OX_TRUST_ACTIVE));
+				assertEquals("locale",copy.getAttribute(OX_TRUST_LOCALE));
+				assertEquals("title",copy.getAttribute(OX_TRUST_TITLE));
+				assertEquals("userType",copy.getAttribute(OX_TRUST_USER_TYPE));
+				assertEquals("[{\"value\":\"photo_value\",\"type\":\"photo_type\"}]",copy.getAttribute(OX_TRUST_PHOTOS));
+				assertEquals("[{\"value\":\"ims_value\",\"type\":\"ims_type\"}]",copy.getAttribute(OX_TRUST_IMS_VALUE));
+				assertEquals("[{\"value\":\"phone_value\",\"type\":\"phone_type\"}]",copy.getAttribute(OX_TRUST_PHONE_VALUE));
+				assertEquals("[{\"type\":\"address_type\",\"streetAddress\":\"streetAddress\",\"locality\":null,\"region\":\"region\",\"postalCode\":\"postalCode\",\"country\":\"country\",\"formatted\":\"\",\"primary\":\"address_primary\"}]",copy.getAttribute(OX_TRUST_ADDRESSES));
+				assertEquals("[{\"value\":\"email_value\",\"type\":\"email_type\",\"primary\":\"email_primary\"}]",copy.getAttribute(OX_TRUST_EMAIL));
+				assertEquals("profileUrl",copy.getAttribute(OX_TRUST_PROFILE_URL));
+				assertEquals("nickName",copy.getAttribute(OX_TRUST_NICK_NAME));
+				assertEquals("externalId",copy.getAttribute(OX_TRUST_EXTERNAL_ID));
+				assertEquals("honorificSuffix",copy.getAttribute(OX_TRUSTHONORIFIC_SUFFIX));
+				assertEquals("honorificPrefix",copy.getAttribute(OX_TRUSTHONORIFIC_PREFIX));
+				assertEquals("middleName",copy.getAttribute(OX_TRUST_MIDDLE_NAME));
+			}
+		}.run();
+	}
+	
+	@Test
+	public void testCopyScim1UpdateNullSource() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = new GluuCustomPerson();
+				ScimPerson source = null;
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNull(copy);
+			}
+
+		}.run();
+	}
+	@Test
+	public void testCopyScim1UpdateNullDestination() throws Exception {
+		
+		new ComponentTest() {
+			@Override
+			protected void testComponents() throws Exception {
+				GluuCustomPerson destination = null;
+				ScimPerson source = new ScimPerson();;
+				GluuCustomPerson copy = CopyUtils.copy(source, destination, true);
+				assertNotNull(copy);
+			}
+
+		}.run();
+	}
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockAppInitializer.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockAppInitializer.java
@@ -1,0 +1,14 @@
+package org.gluu.oxtrust.util;
+
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.AutoCreate;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+import org.jboss.seam.annotations.Startup;
+@Startup(depends = "oxTrustConfiguration")
+@AutoCreate
+@Scope(ScopeType.APPLICATION)
+@Name("appInitializer")
+public class MockAppInitializer { //extends AppInitializer {
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockCacheRefreshTimer.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockCacheRefreshTimer.java
@@ -1,0 +1,5 @@
+package org.gluu.oxtrust.util;
+
+public class MockCacheRefreshTimer {
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockEntityIDMonitoringService.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockEntityIDMonitoringService.java
@@ -1,0 +1,5 @@
+package org.gluu.oxtrust.util;
+
+public class MockEntityIDMonitoringService {
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockGroupService.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockGroupService.java
@@ -1,0 +1,104 @@
+package org.gluu.oxtrust.util;
+
+import java.util.List;
+
+import org.gluu.oxtrust.ldap.service.IGroupService;
+import org.gluu.oxtrust.model.GluuGroup;
+import org.gluu.oxtrust.model.GluuGroupVisibility;
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.AutoCreate;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+
+@Scope(ScopeType.STATELESS)
+@Name("groupService")
+@AutoCreate
+public class MockGroupService implements IGroupService{
+
+	@Override
+	public void addGroup(GluuGroup group) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public void removeGroup(GluuGroup group) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public List<GluuGroup> getAllGroups() {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public boolean isMemberOrOwner(String groupDN, String personDN) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public GluuGroup getGroupByInum(String inum) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public String getDnForGroup(String inum) {
+		if("group_value".equals(inum)){
+			return "Mocked DN";		
+		}else if("group_value1".equals(inum)){
+			return "Mocked DN1";
+		}else{
+			return null;
+		}
+	}
+
+	@Override
+	public void updateGroup(GluuGroup group) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public int countGroups() {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public String generateInumForNewGroup() throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public String generateInameForNewGroup(String name) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public List<GluuGroup> searchGroups(String pattern, int sizeLimit) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public GluuGroupVisibility[] getVisibilityTypes() throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public List<GluuGroup> getAllGroupsList() throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public GluuGroup getGroupByDn(String Dn) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public GluuGroup getGroupByIname(String iname) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	@Override
+	public GluuGroup getGroupByDisplayName(String DisplayName) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockImageRepository.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockImageRepository.java
@@ -1,0 +1,15 @@
+package org.gluu.oxtrust.util;
+
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.AutoCreate;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+import org.jboss.seam.annotations.Startup;
+
+@Name("imageRepository")
+@Scope(ScopeType.APPLICATION)
+@AutoCreate
+@Startup
+public class MockImageRepository {//extends ImageRepository {
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockOxTrustConfiguration.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockOxTrustConfiguration.java
@@ -1,0 +1,27 @@
+package org.gluu.oxtrust.util;
+
+import org.gluu.oxtrust.config.OxTrustConfiguration;
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.Install;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+import org.jboss.seam.annotations.Startup;
+
+@Scope(ScopeType.APPLICATION)
+@Name("oxTrustConfiguration")
+@Install(precedence = Install.MOCK)
+@Startup
+public class MockOxTrustConfiguration extends OxTrustConfiguration {
+
+	@Override
+	public void init() {
+		// do not init
+	}
+
+	@Override
+	public void create() {
+		// do not create
+	}
+	
+
+}

--- a/server/src/test/java/org/gluu/oxtrust/util/MockPersonService.java
+++ b/server/src/test/java/org/gluu/oxtrust/util/MockPersonService.java
@@ -1,0 +1,148 @@
+package org.gluu.oxtrust.util;
+
+import java.util.List;
+import java.util.Map;
+
+import org.gluu.oxtrust.ldap.service.IPersonService;
+import org.gluu.oxtrust.model.GluuCustomAttribute;
+import org.gluu.oxtrust.model.GluuCustomPerson;
+import org.gluu.oxtrust.model.User;
+import org.gluu.site.ldap.exception.DuplicateEntryException;
+import org.gluu.site.ldap.persistence.AttributeData;
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.Install;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+import org.xdi.model.GluuAttribute;
+
+@Scope(ScopeType.STATELESS)
+@Name("personService")
+@Install(precedence = Install.MOCK)
+public class MockPersonService implements IPersonService {
+
+	private GluuCustomPerson person;
+	
+	public GluuCustomPerson mockGetPerson() {
+		return person;
+	}
+
+	@Override
+	public void addCustomObjectClass(GluuCustomPerson person) {
+		this.person = person;
+	}
+
+	public void addPerson(GluuCustomPerson person) throws DuplicateEntryException {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public void updatePerson(GluuCustomPerson person) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public void removePerson(GluuCustomPerson person) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> findPersons(GluuCustomPerson person, int sizeLimit) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> searchPersons(String pattern, int sizeLimit, List<GluuCustomPerson> excludedPersons)
+			throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> findAllPersons(String[] returnAttributes) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> findPersonsByUids(List<String> uids, String[] returnAttributes) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson findPersonByDn(String dn, String... returnAttributes) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public boolean containsPerson(GluuCustomPerson person) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public boolean contains(String dn) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson getPersonByDn(String dn) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson getPersonByInum(String inum) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson getPersonByUid(String uid) {
+		if("existing".equals(uid)){
+			return new GluuCustomPerson();
+		}else if("exception".equals(uid)){
+			throw new IllegalStateException("requested Exception");
+		}else{
+			return null;
+		}		
+	}
+
+	public int countPersons() {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public String generateInumForNewPerson() {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public String generateInameForNewPerson(String uid) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public String getDnForPerson(String inum) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public boolean authenticate(String userName, String password) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomAttribute> getMandatoryAtributes() {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public String getPersonString(List<GluuCustomPerson> persons) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public List<GluuCustomPerson> createEntities(Map<String, List<AttributeData>> entriesAttributes) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public boolean isMemberOrOwner(String[] groupDNs, String personDN) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson getPersonByEmail(String email) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public GluuCustomPerson getPersonByAttribute(String attribute, String value) throws Exception {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public void removeAttribute(GluuAttribute attribute) {
+		throw new IllegalStateException("Not Implemented");
+	}
+
+	public User getUserByUid(String uid) {
+		throw new IllegalStateException("Not Implemented");
+	}
+}

--- a/server/src/test/resources/WEB-INF/components.xml
+++ b/server/src/test/resources/WEB-INF/components.xml
@@ -1,0 +1,10 @@
+<components xmlns="http://jboss.com/products/seam/components" 
+            xmlns:core="http://jboss.com/products/seam/core">
+    <component name="oxTrustConfiguration" class="org.gluu.oxtrust.util.MockOxTrustConfiguration" precedence="30" />
+    <component name="appInitializer" class="org.gluu.oxtrust.util.MockAppInitializer" precedence="30" />
+    <component name="imageRepository" class="org.gluu.oxtrust.util.MockImageRepository" precedence="30" />
+    <component name="cacheRefreshTimer" class="org.gluu.oxtrust.util.MockCacheRefreshTimer" precedence="30" />
+    <component name="entityIDMonitoringService" class="org.gluu.oxtrust.util.MockEntityIDMonitoringService" precedence="30" />
+    <component name="personService" class="org.gluu.oxtrust.util.MockPersonService" precedence="30" />
+    <component name="groupService" class="org.gluu.oxtrust.util.MockGroupService" precedence="30" />
+</components>

--- a/server/src/test/resources/log4j.xml
+++ b/server/src/test/resources/log4j.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <!-- The default pattern: Date Priority [Category] Message\n -->
+            <param name="ConversionPattern" value="%d %-5p [%c{6}] %m%n" />
+        </layout>
+    </appender>
+
+ 
+    <!-- ############### oxAuth ################# -->
+    <category name="org.xdi.oxauth">
+        <priority value="TRACE" />
+    </category>
+
+    <!-- ############### Gluu ################# -->
+    <category name="org.gluu">
+        <priority value="INFO" />
+    </category>
+
+    <!-- ############### opnexdi ################# -->
+    <category name="org.openxdi">
+        <priority value="INFO" />
+    </category>
+
+    <!-- ############### oxTrust ################# -->
+    <category name="org.gluu.oxtrust">
+        <priority value="DEBUG" />
+    </category>
+
+    <!-- ############### Embedded JBoss AS ################# -->
+    <category name="org.jboss">
+        <priority value="ERROR" />
+    </category>
+    <category name="com.arjuna">
+        <priority value="ERROR" />
+    </category>
+
+    <!-- EMB-6, JMS activation throws an error due to deployment ordering, but as there is a timeout and retry the tests pass. Hide the error message -->
+    <category name="jboss.resource.adapter.jms.inflow.JmsActivation">
+        <priority value="ERROR" />
+    </category>
+
+    <!-- ############### Hibernate logging ################# -->
+
+    <category name="org.hibernate">
+        <priority value="ERROR" />
+    </category>
+
+    <!-- <category name="org.hibernate.SQL"> <priority value="TRACE"/> </category> <category name="org.hibernate.type"> <priority value="TRACE"/> </category> <category name="org.hibernate.loader"> <priority 
+        value="TRACE"/> </category> <category name="org.hibernate.cache"> <priority value="TRACE"/> </category> -->
+
+    <!-- Ajax4jsf is too noisy -->
+    <category name="org.ajax4jsf.cache">
+        <priority value="WARN" />
+    </category>
+
+
+    <!-- ############### Seam logging ################### -->
+    <category name="org.jboss.seam">
+        <priority value="INFO" />
+    </category>
+
+
+
+    <!-- These things are too noisy <category name="org.jboss.seam.jsf.SeamVariableResolver"> <priority value="INFO"/> </category> <category name="org.jboss.seam.contexts.Contexts"> <priority value="INFO"/> 
+        </category> <category name="org.jboss.seam.Component"> <priority value="INFO"/> </category> <category name="org.jboss.seam.deployment.Scanner"> <priority value="INFO"/> </category> <category name="org.jboss.seam.util.Naming"> 
+        <priority value="INFO"/> </category> <category name="org.jboss.seam.debug.hot"> <priority value="INFO"/> </category> <category name="org.jboss.seam.core.Events"> <priority value="INFO"/> </category> -->
+
+    <!-- Debugging conversations and persistence contexts <category name="org.jboss.seam.core.Manager"> <priority value="DEBUG"/> </category> <category name="org.jboss.seam.core.ManagedPersistenceContext"> 
+        <priority value="DEBUG"/> </category> <category name="org.jboss.seam.jsf.AbstractSeamPhaseListener"> <priority value="DEBUG"/> </category> <category name="org.jboss.seam.interceptors.ConversationInterceptor"> 
+        <priority value="DEBUG"/> </category> <category name="org.jboss.seam.contexts.Lifecycle"> <priority value="DEBUG"/> </category> <category name="org.hibernate.impl.SessionImpl"> <priority value="DEBUG"/> 
+        </category> <category name="org.hibernate.event.def.AbstractFlushingEventListener"> <priority value="DEBUG"/> </category> -->
+
+    <!-- ================ -->
+    <!-- OX loggers -->
+    <!-- ================ -->
+
+    <logger name="org.gluu.site.ldap.persistence" additivity="false">
+        <level value="INFO" />
+        <appender-ref ref="OX_TRUST_PERSISTENCE_FILE" />
+    </logger>
+
+    <logger name="com.unboundid.ldap.sdk.LDAPConnection" additivity="false">
+        <level value="DEBUG" />
+        <appender-ref ref="OX_TRUST_PERSISTENCE_FILE" />
+    </logger>
+
+    <logger name="org.gluu.oxtrust.ldap.service.staus.ldap" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="OX_TRUST_PERSISTENCE_LDAP_STATISTICS_FILE" />
+    </logger>
+
+    <logger name="org.gluu.oxtrust.service.external.ExternalCacheRefreshService" additivity="false">
+        <level value="DEBUG" />
+        <appender-ref ref="OX_TRUST_CACHE_REFRESH_PYTHON_FILE" />
+    </logger>
+
+    <logger name="org.gluu.oxtrust.ldap.cache.service" additivity="false">
+        <level value="DEBUG" />
+        <appender-ref ref="OX_TRUST_CACHE_REFRESH_FILE" />
+    </logger>
+
+    <logger name="org.gluu.oxtrust.action.ConfigureCacheRefreshAction" additivity="false">
+        <level value="DEBUG" />
+        <appender-ref ref="OX_TRUST_CACHE_REFRESH_FILE" />
+    </logger>
+
+    <logger name="org.xdi.service.PythonService" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="OX_TRUST_SCRIPT_LOG_FILE" />
+    </logger>
+
+    <logger name="org.xdi.service.custom.script" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="OX_TRUST_SCRIPT_LOG_FILE" />
+    </logger>
+
+    <logger name="org.gluu.oxtrust.service.custom" additivity="false">
+        <level value="DEBUG"/>
+        <appender-ref ref="OX_TRUST_SCRIPT_LOG_FILE" />
+    </logger>
+
+    <root>
+        <priority value="INFO" />
+        <appender-ref ref="FILE" />
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
Hi,
In order to get my scimclient working I needed to fix/change some things in the copyUtils. It was not possible to remove attributes from a created person. (It might have to do with issue #96) While testing I found that the currently used attribute names were not up to date with the ldap schema so I did not get back my expected results.  I created Unittests for the CopyUtils to fix the current behaviour. 
While working on the code I also did some refactoring. Most significant changes:
-Unittest for CopyUtils copy person (introduced Interface of personService and groupService to allow mocking in test)
-refactor of copy(ScimPerson source, GluuCustomPerson destination, boolean isUpdate)
-update of attributenames to match current ldap scheme


I think similar work needs to be done on groups and CopyUtils2. But this might be a base for merging the CopyUtils.

kind regards
  Dieder Timmers