### PR TITLE
Fixed person removal from oxTrust.

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/PersonService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/PersonService.java
@@ -135,7 +135,7 @@ public class PersonService implements Serializable {
 		}
 
 		// Remove person
-		ldapEntryManager.remove(person);
+		ldapEntryManager.removeWithSubtree(person.getDn());
 	}
 
 	/**


### PR DESCRIPTION
Removing persons from oxTrust application failed because person entries have ou=clientAuthorizations subentry. This caused following kind of error to be written to log when trying to remove person in oxTrust UI:

INFO   | jvm 1    | 2016/01/08 08:21:00 | Caused by: Connection exception (Failed to delete entry: The entry 'inum=@!D0B3.42FF.3A77.681D!0001!0105.03F6!0000!2D71.4D15,ou=people,o=@!D0B3.42FF.3A77.681D!0001!010
5.03F6,o=gluu' cannot be removed because it has subordinate entries)
