### PR TITLE
Added removal of sessions to user removal.

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/model/OxAuthSessionId.java
+++ b/server/src/main/java/org/gluu/oxtrust/model/OxAuthSessionId.java
@@ -1,0 +1,27 @@
+package org.gluu.oxtrust.model;
+
+import java.io.Serializable;
+
+import org.gluu.site.ldap.persistence.annotation.LdapAttribute;
+import org.gluu.site.ldap.persistence.annotation.LdapEntry;
+import org.gluu.site.ldap.persistence.annotation.LdapObjectClass;
+import org.xdi.ldap.model.Entry;
+
+@LdapEntry(sortBy = { "uniqueIdentifier" })
+@LdapObjectClass(values = { "top", "oxAuthSessionId" })
+public class OxAuthSessionId extends Entry implements Serializable {
+
+	private static final long serialVersionUID = -4317830415164467231L;
+
+	@LdapAttribute(ignoreDuringUpdate = true)
+	private String uniqueIdentifier;
+
+	public String getUniqueIdentifier() {
+		return uniqueIdentifier;
+	}
+
+	public void setUniqueIdentifier(String uniqueIdentifier) {
+		this.uniqueIdentifier = uniqueIdentifier;
+	}
+	
+}


### PR DESCRIPTION
Added removal of sessions to oxTrust user removal. This was needed because when deleted users accessed oxAuth authorization endpoint with session_id cookie, `org.xdi.oxauth.authorize.ws.rs.AuthorizeAction` was throwing an exception when it tried to retrieve the user entry corresponding to the value of the `oxAuthUserDN` attribute of the session. This user entry obviously did not exist.
