### PR TITLE
Catalina.base

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/FilterService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/FilterService.java
@@ -63,7 +63,7 @@ public class FilterService {
 	private Shibboleth2ConfService shibboleth2ConfService;
 
 	public List<MetadataFilter> getAvailableMetadataFilters() {
-		File filterFolder = new File(System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "shibboleth2"
+		File filterFolder = new File(System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "shibboleth2"
 				+ File.separator + "idp" + File.separator + "MetadataFilter");
 		File[] filterTemplates = null;
 		if (filterFolder.exists() && filterFolder.isDirectory()) {

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/LogFileSizeChecker.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/LogFileSizeChecker.java
@@ -94,10 +94,10 @@ public class LogFileSizeChecker {
 			String todayStr = sdf.format(today);
 
 			String filePath = "";
-			String tomcatHome = System.getProperty("catalina.home");
+			String tomcatHome = System.getProperty("catalina.base");
 			if (tomcatHome != null) {
 				log.debug("Setting the tomcat home directory");
-				filePath = System.getProperty("catalina.home") + File.separator + "conf" + File.separator
+				filePath = System.getProperty("catalina.base") + File.separator + "conf" + File.separator
 						+ OxTrustConfiguration.LOG_ROTATION_CONFIGURATION;
 				log.debug("FilePath: " + filePath);
 			} else {

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/ProfileConfigurationService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/ProfileConfigurationService.java
@@ -56,7 +56,7 @@ public class ProfileConfigurationService {
 	private TemplateService templateService;
 
 	public List<ProfileConfiguration> getAvailableProfileConfigurations() {
-		File profileConfigurationFolder = new File(System.getProperty("catalina.home") + File.separator + "conf" + File.separator
+		File profileConfigurationFolder = new File(System.getProperty("catalina.base") + File.separator + "conf" + File.separator
 				+ "shibboleth2" + File.separator + "idp" + File.separator + "ProfileConfiguration");
 		File[] profileConfigurationTemplates = null;
 		if (profileConfigurationFolder.exists() && profileConfigurationFolder.isDirectory()) {

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/Shibboleth2ConfService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/Shibboleth2ConfService.java
@@ -1283,7 +1283,7 @@ public class Shibboleth2ConfService implements Serializable {
 		newFactory.setValidating(false);
 		DocumentBuilder xmlParser = newFactory.newDocumentBuilder();
 		Document xmlDoc = xmlParser.parse(stream);
-		String schemaDir = System.getProperty("catalina.home") 
+		String schemaDir = System.getProperty("catalina.base") 
 		                        + File.separator + "conf" + File.separator + "shibboleth2" + File.separator
 		                        + "idp" + File.separator + "schema" + File.separator;
 		Schema schema = SchemaBuilder.buildSchema(SchemaLanguage.XML, schemaDir);

--- a/server/src/main/java/org/gluu/oxtrust/ldap/service/TemplateService.java
+++ b/server/src/main/java/org/gluu/oxtrust/ldap/service/TemplateService.java
@@ -72,7 +72,7 @@ public class TemplateService implements Serializable {
 	}
 
 	public boolean writeApplicationConfFile(String confFile, String conf) {
-		return writeConfFile(System.getProperty("catalina.home") + File.separator + "conf" + File.separator + confFile, conf);
+		return writeConfFile(System.getProperty("catalina.base") + File.separator + "conf" + File.separator + confFile, conf);
 	}
 
 	/*
@@ -88,18 +88,18 @@ public class TemplateService implements Serializable {
 
 			// Set right folder for file loader
 			if (loaderType.indexOf("file") == 0) {
-				String folder1 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "shibboleth2"
+				String folder1 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "shibboleth2"
 						+ File.separator + "idp";
-				String folder2 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "shibboleth2"
+				String folder2 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "shibboleth2"
 						+ File.separator + "sp";
-				String folder3 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "ldif";
-				String folder4 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "shibboleth2"
+				String folder3 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "ldif";
+				String folder4 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "shibboleth2"
 						+ File.separator + "idp" + File.separator + "MetadataFilter";
-				String folder5 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "shibboleth2"
+				String folder5 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "shibboleth2"
 						+ File.separator + "idp" + File.separator + "ProfileConfiguration";
-				String folder6 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "template"
+				String folder6 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "template"
 						+ File.separator + "conf";
-				String folder7 = System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "template"
+				String folder7 = System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "template"
 						+ File.separator + "shibboleth2";
 				properties.setProperty("file.resource.loader.path", folder1 + ", " + folder2 + ", " + folder3 + ", " + folder4 + ", "
 						+ folder5 + ", " + folder6  + ", " + folder7);

--- a/server/src/main/resources/log4j.xml
+++ b/server/src/main/resources/log4j.xml
@@ -15,7 +15,7 @@
     <!-- ================ -->
 
     <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxtrust.log" />
+        <param name="File" value="${catalina.base}/logs/oxtrust.log" />
         <param name="DatePattern" value="'.'yyyy-MM-dd" />
         <layout class="org.apache.log4j.PatternLayout">
             <!-- The default pattern: Date Priority [Category] Message\n -->
@@ -24,7 +24,7 @@
     </appender>
 
     <appender name="OX_TRUST_PERSISTENCE_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxtrust_persistence.log" />
+        <param name="File" value="${catalina.base}/logs/oxtrust_persistence.log" />
         <param name="DatePattern" value="'.'yyyy-MM-dd" />
 
         <layout class="org.apache.log4j.PatternLayout">
@@ -34,7 +34,7 @@
     </appender>
 
     <appender name="OX_TRUST_PERSISTENCE_LDAP_STATISTICS_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxtrust_persistence_ldap_statistics.log" />
+        <param name="File" value="${catalina.base}/logs/oxtrust_persistence_ldap_statistics.log" />
         <param name="DatePattern" value="'.'yyyy-MM-dd" />
 
         <layout class="org.apache.log4j.PatternLayout">
@@ -44,7 +44,7 @@
     </appender>
 
     <appender name="OX_TRUST_CACHE_REFRESH_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxtrust_cache_refresh.log" />
+        <param name="File" value="${catalina.base}/logs/oxtrust_cache_refresh.log" />
         <param name="DatePattern" value="'.'yyyy-MM-dd" />
 
         <layout class="org.apache.log4j.PatternLayout">
@@ -54,7 +54,7 @@
     </appender>
 
     <appender name="OX_TRUST_CACHE_REFRESH_PYTHON_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxtrust_cache_refresh_python.log" />
+        <param name="File" value="${catalina.base}/logs/oxtrust_cache_refresh_python.log" />
         <param name="DatePattern" value="'.'yyyy-MM-dd" />
 
         <layout class="org.apache.log4j.PatternLayout">
@@ -64,7 +64,7 @@
     </appender>
 
     <appender name="OX_TRUST_SCRIPT_LOG_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-         <param name="File" value="${catalina.home}/logs/oxtrust_script.log"/>
+         <param name="File" value="${catalina.base}/logs/oxtrust_script.log"/>
          <param name="DatePattern" value="'.'yyyy-MM-dd"/>
 
          <layout class="org.apache.log4j.PatternLayout">

--- a/server/src/test/java/org/gluu/oxtrust/action/test/ConfigurableTest.java
+++ b/server/src/test/java/org/gluu/oxtrust/action/test/ConfigurableTest.java
@@ -29,7 +29,7 @@ public abstract class ConfigurableTest extends JUnitSeamTest {
 	@Before
 	public void initTest() {
 		super.begin();
-		this.testData = new TestFileConfiguration(System.getProperty("catalina.home") + File.separator + "conf" + File.separator + "oxTrustLdapTest.properties");
+		this.testData = new TestFileConfiguration(System.getProperty("catalina.base") + File.separator + "conf" + File.separator + "oxTrustLdapTest.properties");
 	}
 
 	/**


### PR DESCRIPTION
Tomcat allows multiple instances to be installed using the same binary. In debian, this is performed by the tomcat7-user package. In centos, this can be achieved by customizing the init script and copying a skeleton tomcat directory structure. In both cases, tomcat sets the CATALINA_HOME environment variable (catalina.home for java) to the location of the tomcat binary, and the CATALINA_BASE environment variable (catalina.base for java) to the location of the tomcat installation. catalina.sh describes that CATALINA_BASE will be set to CATALINA_HOME if not present.

    #   CATALINA_HOME   May point at your Catalina "build" directory.
    #
    #   CATALINA_BASE   (Optional) Base directory for resolving dynamic portions
    #                   of a Catalina installation.  If not present, resolves to
    #                   the same directory that CATALINA_HOME points to.

Since CATALINA_BASE contains the "dynamic portions" of the Catalina installation, this is the appropriate place to look for config and log files.

These patches modify where oxTrust looks for its logfiles / config files to be under catalina.base rather than catalina.home for compatibility with multiple tomcat instances.