### PR TITLE
Trivial grammatical improvement

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/action/PersonImportAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/PersonImportAction.java
@@ -155,7 +155,7 @@ public class PersonImportAction implements Serializable {
 
 		}
 
-		log.info("All persons {0} added successfully", fileDataToImport.getPersons().size());
+		log.info("All {0} persons added successfully", fileDataToImport.getPersons().size());
 
 		removeFileToImport();
 


### PR DESCRIPTION
Because "All 26 persons added successfully" reads better than "All persons 26 added successfully".