### PR TITLE
Implicit trust to host mail server

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/util/MailUtils.java
+++ b/server/src/main/java/org/gluu/oxtrust/util/MailUtils.java
@@ -72,6 +72,7 @@ public class MailUtils {
 		props.put("mail.smtp.timeout", this.connectionTimeout);
 		props.put("mail.debug", true);
 		props.put("mail.transport.protocol", "smtp");
+		props.put("mail.smtp.ssl.trust", this.hostName);
 		if (requiresSsl) {
 			// props.put("mail.smtp.socketFactory.port", "465");
 			props.put("mail.smtp.starttls.enable", true);


### PR DESCRIPTION
Resolves an issue found https://stackoverflow.com/questions/16115453/javamail-could-not-convert-socket-to-tls-gmail which resulted in a generic error message to the user.