### PR TITLE
Update relying-party.xml.vm

### DIFF
--- a/configuration/template/shibboleth3/idp/relying-party.xml.vm
+++ b/configuration/template/shibboleth3/idp/relying-party.xml.vm
@@ -73,7 +73,7 @@
         #set ($profileConfigMap = $trustRelationship.profileConfigurations)
         <!--#if(!$profileConfigMap.isEmpty())-->
 
-        #set($entityId = $trustParams.trustEntityIds.get($trustRelationship.inum).get(0))
+        #set($entityId = $trustRelationship.getEntityId())
         #set($relyingPartyId = $StringHelper.removePunctuation($trustRelationship.inum))
 
         <bean parent="RelyingPartyByName" id="$relyingPartyId" c:relyingPartyIds="$entityId">


### PR DESCRIPTION
In elements generated for TRs based on Fed TR "$entityId" variable in the specified line isn't assigned any value, thus not being dereferenced correctly later in the document - due to the fact instruction "$trustParams.trustEntityIds.get($trustRelationship.inum).get(0)" doesn't return any value for this kind of TR (it works fine for file and url based TRs, though). This, in its turn, happens because "trustParams.trustEntityIds" dict uses inum of the federation - not the TR's derived from it - as a key for the entityid.

It's not clear to me why we need to fetch entityid for the currently processed TR in such elaborated way, in the first place, when by simply using "$trustRelationship.getEntityId()" instruction we can achieve the same result, regardless of type of the TR (that what's my fix suggests to use).