### PR TITLE
Potential issue related to the use of ApacheHttpClient43Engine

### DIFF
--- a/service/src/main/java/org/gluu/oxtrust/auth/uma/UmaPermissionService.java
+++ b/service/src/main/java/org/gluu/oxtrust/auth/uma/UmaPermissionService.java
@@ -41,7 +41,7 @@ import org.gluu.util.Pair;
 import org.gluu.util.StringHelper;
 import org.jboss.resteasy.client.core.executors.ApacheHttpClient4Executor;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
-import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.jboss.resteasy.client.jaxrs.engines.factory.ApacheHttpClient4EngineFactory;
 import org.slf4j.Logger;
 
 /**
@@ -70,7 +70,8 @@ public class UmaPermissionService implements Serializable {
 	private final Pair<Boolean, Response> authenticationFailure = new Pair<Boolean, Response>(false, null);
 	private final Pair<Boolean, Response> authenticationSuccess = new Pair<Boolean, Response>(true, null);
 
-	private ApacheHttpClient4Engine clientHttpEngine;
+	//private ApacheHttpClient4Engine clientHttpEngine;
+	private ClientHttpEngine clientHttpEngine;
 
 	@PostConstruct
 	public void init() {
@@ -91,7 +92,8 @@ public class UmaPermissionService implements Serializable {
 							.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
 							.setKeepAliveStrategy(connectionKeepAliveStrategy).setConnectionManager(connectionManager)
 							.build();
-					this.clientHttpEngine = new ApacheHttpClient4Engine(client);
+					//this.clientHttpEngine = new ApacheHttpClient4Engine(client);
+					this.clientHttpEngine = ApacheHttpClient4EngineFactory.create(client);
 					log.info("##### Initializing custom ClientExecutor DONE");
 
 					this.permissionService = UmaClientFactory.instance().createPermissionService(this.umaMetadata,


### PR DESCRIPTION
Using such a concrete class as `ApacheHttpClient43Engine` brings the same issue that the usage of `ApacheHttpClient4Engine` brought , which is , in further versions , it may be obsoleted/deprecated or outright removed. 
Replacing with the `ClientHttpService` which is returned by `ApacheHttpClient4HttpFactory` which internally will choose the better implementation to use. 