### PR TITLE
Trim leading and trailing spaces in CR server IP address

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/action/ConfigureCacheRefreshAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/ConfigureCacheRefreshAction.java
@@ -236,7 +236,7 @@ public class ConfigureCacheRefreshAction
 		GluuConfiguration configuration = configurationService.getConfiguration();
 		configuration.setVdsCacheRefreshEnabled(this.configuration.isVdsCacheRefreshEnabled());
 		configuration.setVdsCacheRefreshPollingInterval(this.configuration.getVdsCacheRefreshPollingInterval());
-		configuration.setCacheRefreshServerIpAddress(this.configuration.getCacheRefreshServerIpAddress());
+		configuration.setCacheRefreshServerIpAddress(this.configuration.getCacheRefreshServerIpAddress().trim());
 		configurationService.updateConfiguration(configuration);
 	}
 


### PR DESCRIPTION
Under the "Cache Refresh" form, a user is able to insert the oxTrust server
IP. [As per documentation](https://gluu.org/docs/gluu-server/user-management/ldap-sync/#attributes-mapping), even in clustered mode, this will be a single
of the server that will fetch data from LDAP/AD instances. An issue
arose due to lack of validation that the user inserts a valid IP address.

As a first step, in order to provide a better UX and avoid annoying
issues where spaces find their way into the form field (either pasted or
by mistake), all spaces should be trimmed on the backend.

If there's a more appropriate place for trimming the spaces, or there's something I'm misunderstanding, let me know.

Heads up: I don't have a working dev environment for Java/oxTrust, hence I have not tested this thoroughly.