### PR TITLE
fix: disabled multivalued check box for mysql db

### DIFF
--- a/server/src/main/java/org/gluu/oxtrust/action/UpdateAttributeAction.java
+++ b/server/src/main/java/org/gluu/oxtrust/action/UpdateAttributeAction.java
@@ -537,5 +537,9 @@ public class UpdateAttributeAction implements Serializable {
     public GluuAttributeUsageType[] getAttributeUsageTypes() {
         return attributeService.getAttributeUsageTypes();
     }
+    
+    public String getPersistenceType() {
+		return attributeService.getPersistenceType();
+	}
 
 }

--- a/server/src/main/webapp/WEB-INF/incl/attribute/attributeForm.xhtml
+++ b/server/src/main/webapp/WEB-INF/incl/attribute/attributeForm.xhtml
@@ -117,7 +117,7 @@
 						<h:selectBooleanCheckbox
 							value="#{_attribute.oxMultiValuedAttribute}" id="multivaluedId"
 							styleClass="form-control multivaluedField"
-							disabled="#{not _attributeAction.canEdit()}">
+							disabled="#{not _attributeAction.canEdit() or _attributeAction.persistenceType eq 'sql'}">
 							<a4j:ajax event="click" render="validation" />
 						</h:selectBooleanCheckbox>
 					</ox:decorate>

--- a/service/src/main/java/org/gluu/oxtrust/service/AttributeService.java
+++ b/service/src/main/java/org/gluu/oxtrust/service/AttributeService.java
@@ -636,5 +636,10 @@ public class AttributeService extends org.gluu.service.AttributeService {
     protected BaseCacheService getCacheService() {
         return cacheService;
     }
+    
+    public String getPersistenceType() {
+		return persistenceEntryManager.getPersistenceType();
+	}
+
 
 }


### PR DESCRIPTION
https://github.com/GluuFederation/oxTrust/issues/2175 : for 4.4.1 disabled multivalued check box for mysql db as we can't change the MySql table definitions after installation.